### PR TITLE
Add more response information to api error.

### DIFF
--- a/payjp/build.gradle
+++ b/payjp/build.gradle
@@ -15,10 +15,13 @@ android {
         java.srcDirs += "src/${name}/kotlin"
     }
 
+    testOptions {
+        unitTests.returnDefaultValues = true
+    }
 }
 
 dependencies {
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlin_version"
 
     implementation "com.android.support:appcompat-v7:$supportLib"
 
@@ -30,6 +33,8 @@ dependencies {
     implementation "com.squareup.retrofit2:converter-moshi:$retrofit"
 
     testImplementation 'junit:junit:4.12'
+    testImplementation "org.robolectric:robolectric:3.5.1"
+    testImplementation "com.squareup.okhttp3:mockwebserver:$okHttp"
 }
 
 task dokkaJavadoc(type: org.jetbrains.dokka.gradle.DokkaTask) {

--- a/payjp/src/main/kotlin/jp/pay/android/SingletonFactory.kt
+++ b/payjp/src/main/kotlin/jp/pay/android/SingletonFactory.kt
@@ -21,17 +21,33 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package jp.pay.android.model
+package jp.pay.android
 
 /**
- * Error
- *
- * cf. https://pay.jp/docs/api/#error
- *
- * @param code error code e.g. `invalid_number`
- * @param message system message (should not show to end user)
- * @param type error type e.g. `card_error`
+ * Singleton factory
  */
-data class ApiError(val code: String?,
-                    val message: String,
-                    val type: String)
+internal class SingletonFactory<T> {
+    @Volatile private var instance: T? = null
+
+    fun init(initializer: () -> T): T {
+        if (instance == null) {
+            synchronized(this) {
+                if (instance == null) {
+                    instance = initializer()
+                }
+            }
+        }
+        @Suppress("UNCHECKED_CAST")
+        return instance as T
+    }
+
+    fun get(): T {
+        if (instance == null) {
+            synchronized(this) {
+                check(instance != null) { "instance is not initialized." }
+            }
+        }
+        @Suppress("UNCHECKED_CAST")
+        return instance as T
+    }
+}

--- a/payjp/src/main/kotlin/jp/pay/android/exception/PayjpApiException.kt
+++ b/payjp/src/main/kotlin/jp/pay/android/exception/PayjpApiException.kt
@@ -27,7 +27,15 @@ import jp.pay.android.model.ApiError
 
 /**
  * PayjpApiException
+ *
+ * @param message message
+ * @param cause cause throwable
+ * @param httpStatusCode code e.g. `400`
+ * @param apiError error information from api response
+ * @param source raw json string
  */
 class PayjpApiException(override val message: String,
+                        override val cause: Throwable,
                         val httpStatusCode: Int,
-                        val apiError: ApiError) : RuntimeException(message)
+                        val apiError: ApiError,
+                        val source: String?) : RuntimeException(message, cause)

--- a/payjp/src/main/kotlin/jp/pay/android/network/TokenApiClientFactory.kt
+++ b/payjp/src/main/kotlin/jp/pay/android/network/TokenApiClientFactory.kt
@@ -1,0 +1,72 @@
+/*
+ *
+ * Copyright (c) 2017 PAY.JP (https://pay.jp)
+ * Copyright (c) 2017 BASE, Inc. (https://binc.jp/)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package jp.pay.android.network
+
+import com.squareup.moshi.KotlinJsonAdapterFactory
+import com.squareup.moshi.Moshi
+import jp.pay.android.TokenApi
+import jp.pay.android.model.CardBrand
+import jp.pay.android.model.DateUnixTimeJsonAdapter
+import okhttp3.Dispatcher
+import okhttp3.OkHttpClient
+import okhttp3.logging.HttpLoggingInterceptor
+import retrofit2.Retrofit
+import retrofit2.converter.moshi.MoshiConverterFactory
+import java.util.concurrent.Executor
+
+/**
+ * ApiClient factory
+ */
+internal fun createOkHttp(debuggable: Boolean = false) =
+        OkHttpClient.Builder()
+                .addInterceptor(UaRequestInterceptor())
+                .apply {
+                    if (debuggable) {
+                        addNetworkInterceptor(HttpLoggingInterceptor()
+                                .apply { this.level = HttpLoggingInterceptor.Level.HEADERS })
+                    }
+                }
+                .enableTls12OnPreLollipop()
+                .dispatcher(Dispatcher(NetworkExecutorFactory.create()))
+                .build()
+
+internal fun createMoshi() =
+        Moshi.Builder()
+                .add(KotlinJsonAdapterFactory())
+                .add(CardBrand.JsonAdapter())
+                .add(DateUnixTimeJsonAdapter())
+                .build()
+
+internal fun createApiClient(baseUrl: String,
+                             debuggable: Boolean = false,
+                             callbackExecutor: Executor): TokenApi =
+        createMoshi().let { moshi ->
+            Retrofit.Builder()
+                    .baseUrl(baseUrl)
+                    .client(createOkHttp(debuggable))
+                    .addCallAdapterFactory(ResultCallAdapterFactory(moshi, callbackExecutor))
+                    .addConverterFactory(MoshiConverterFactory.create(moshi))
+                    .build()
+                    .create(TokenApi::class.java)
+        }

--- a/payjp/src/test/kotlin/jp/pay/android/PayjpTokenTest.kt
+++ b/payjp/src/test/kotlin/jp/pay/android/PayjpTokenTest.kt
@@ -1,0 +1,308 @@
+/*
+ *
+ * Copyright (c) 2017 PAY.JP (https://pay.jp)
+ * Copyright (c) 2017 BASE, Inc. (https://binc.jp/)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package jp.pay.android
+
+import jp.pay.android.exception.PayjpApiException
+import jp.pay.android.network.createApiClient
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.fail
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import retrofit2.HttpException
+import java.io.IOException
+import java.nio.charset.Charset
+import java.util.concurrent.Executor
+
+/**
+ * [PayjpToken]
+ */
+@RunWith(RobolectricTestRunner::class)
+class PayjpTokenTest {
+
+    private val mockWebServer = MockWebServer()
+    internal inner class CurrentThreadExecutor : Executor {
+        override fun execute(r: Runnable) {
+            r.run()
+        }
+    }
+
+    @Before
+    fun setUp() {
+        mockWebServer.start()
+    }
+
+    @After
+    fun tearDown() {
+        mockWebServer.shutdown()
+    }
+
+    // pk_test_0383a1b8f91e8a6e3ea0e2a9
+    // Basic cGtfdGVzdF8wMzgzYTFiOGY5MWU4YTZlM2VhMGUyYTk6
+    private val configuration =
+            PayjpTokenConfiguration.Builder(publicKey = "pk_test_0383a1b8f91e8a6e3ea0e2a9").build()
+
+    @Test
+    fun createToken_ok() {
+        mockWebServer.enqueue(MockResponse().setResponseCode(200).setBody(TOKEN_OK))
+
+        PayjpToken(configuration = configuration,
+                tokenApi = createApiClient(baseUrl = mockWebServer.url("/").toString(),
+                        callbackExecutor = CurrentThreadExecutor()))
+                .createToken(number = "4242424242424242", cvc = "123", expMonth = "02", expYear = "2020")
+                .run()
+                .let { token ->
+                    assertEquals("tok_5ca06b51685e001723a2c3b4aeb4", token.id)
+                    assertEquals("car_e3ccd4e0959f45e7c75bacc4be90", token.card.id)
+                }
+
+        mockWebServer.takeRequest()
+                .let { request ->
+                    assertEquals("POST", request.method)
+                    assertEquals("/tokens", request.path)
+                    assertEquals("Basic cGtfdGVzdF8wMzgzYTFiOGY5MWU4YTZlM2VhMGUyYTk6",
+                            request.getHeader("Authorization"))
+                    assertEquals("card%5Bnumber%5D=4242424242424242" +
+                            "&card%5Bcvc%5D=123" +
+                            "&card%5Bexp_month%5D=02" +
+                            "&card%5Bexp_year%5D=2020",
+                            request.body.readString(Charset.forName("utf-8")))
+                }
+    }
+
+    @Test
+    fun createToken_auth_error() {
+        mockWebServer.enqueue(MockResponse().setResponseCode(401).setBody(ERROR_AUTH))
+
+        val task = PayjpToken(configuration = configuration,
+                tokenApi = createApiClient(baseUrl = mockWebServer.url("/").toString(),
+                        callbackExecutor = CurrentThreadExecutor()))
+                .createToken(number = "4242424242424242", cvc = "123", expMonth = "02", expYear = "2020")
+
+        try {
+            task.run()
+            fail()
+        } catch (e: PayjpApiException) {
+            assertEquals("Invalid API Key: {0}", e.message)
+            assertEquals(HttpException::class.java, e.cause::class.java)
+            assertEquals(401, e.httpStatusCode)
+            assertEquals("auth_error", e.apiError.type)
+            assertEquals(null, e.apiError.code)
+            assertEquals(ERROR_AUTH, e.source)
+        }
+    }
+
+    @Test
+    fun createToken_card_error() {
+        mockWebServer.enqueue(MockResponse().setResponseCode(402).setBody(ERROR_CARD_DECLINED))
+
+        val task = PayjpToken(configuration = configuration,
+                tokenApi = createApiClient(baseUrl = mockWebServer.url("/").toString(),
+                        callbackExecutor = CurrentThreadExecutor()))
+                .createToken(number = "4000000000000002", cvc = "123", expMonth = "02", expYear = "2020")
+
+        try {
+            task.run()
+            fail()
+        } catch (e: PayjpApiException) {
+            assertEquals("Card declined", e.message)
+            assertEquals(HttpException::class.java, e.cause::class.java)
+            assertEquals(402, e.httpStatusCode)
+            assertEquals("card_error", e.apiError.type)
+            assertEquals("card_declined", e.apiError.code)
+            assertEquals(ERROR_CARD_DECLINED, e.source)
+        }
+    }
+
+    @Test
+    fun createToken_server_error() {
+        mockWebServer.enqueue(MockResponse().setResponseCode(501))
+
+        val task = PayjpToken(configuration = configuration,
+                tokenApi = createApiClient(baseUrl = mockWebServer.url("/").toString(),
+                        callbackExecutor = CurrentThreadExecutor()))
+                .createToken(number = "4242424242424242", cvc = "123", expMonth = "02", expYear = "2020")
+
+        try {
+            task.run()
+            fail()
+        } catch (e: IOException) {
+        }
+    }
+
+    @Test
+    fun getToken_ok() {
+        mockWebServer.enqueue(MockResponse().setResponseCode(200).setBody(TOKEN_OK))
+
+        PayjpToken(configuration = configuration,
+                tokenApi = createApiClient(baseUrl = mockWebServer.url("/").toString(),
+                        callbackExecutor = CurrentThreadExecutor()))
+                .getToken("tok_5ca06b51685e001723a2c3b4aeb4")
+                .run()
+                .let { token ->
+                    assertEquals("tok_5ca06b51685e001723a2c3b4aeb4", token.id)
+                    assertEquals("car_e3ccd4e0959f45e7c75bacc4be90", token.card.id)
+                }
+
+        mockWebServer.takeRequest()
+                .let { request ->
+                    assertEquals("GET", request.method)
+                    assertEquals("/tokens/tok_5ca06b51685e001723a2c3b4aeb4", request.path)
+                    assertEquals("Basic cGtfdGVzdF8wMzgzYTFiOGY5MWU4YTZlM2VhMGUyYTk6",
+                            request.getHeader("Authorization"))
+                }
+    }
+
+    @Test
+    fun getToken_auth_error() {
+        mockWebServer.enqueue(MockResponse().setResponseCode(401).setBody(ERROR_AUTH))
+
+        val task = PayjpToken(configuration = configuration,
+                tokenApi = createApiClient(baseUrl = mockWebServer.url("/").toString(),
+                        callbackExecutor = CurrentThreadExecutor()))
+                .getToken("tok_5ca06b51685e001723a2c3b4aeb4")
+
+        try {
+            task.run()
+            fail()
+        } catch (e: PayjpApiException) {
+            assertEquals("Invalid API Key: {0}", e.message)
+            assertEquals(HttpException::class.java, e.cause::class.java)
+            assertEquals(401, e.httpStatusCode)
+            assertEquals("auth_error", e.apiError.type)
+            assertEquals(null, e.apiError.code)
+            assertEquals(ERROR_AUTH, e.source)
+        }
+    }
+
+    @Test
+    fun getToken_client_error() {
+        mockWebServer.enqueue(MockResponse().setResponseCode(404).setBody(ERROR_INVALID_ID))
+
+        val task = PayjpToken(configuration = configuration,
+                tokenApi = createApiClient(baseUrl = mockWebServer.url("/").toString(),
+                        callbackExecutor = CurrentThreadExecutor()))
+                .getToken("tok_587af2665fdced4742e5fbb3ecfcaa")
+
+        try {
+            task.run()
+            fail()
+        } catch (e: PayjpApiException) {
+            assertEquals("No such token: tok_587af2665fdced4742e5fbb3ecfcaa", e.message)
+            assertEquals(HttpException::class.java, e.cause::class.java)
+            assertEquals(404, e.httpStatusCode)
+            assertEquals("client_error", e.apiError.type)
+            assertEquals("invalid_id", e.apiError.code)
+            assertEquals(ERROR_INVALID_ID, e.source)
+        }
+    }
+
+    @Test
+    fun getToken_server_error() {
+        mockWebServer.enqueue(MockResponse().setResponseCode(501))
+
+        val task = PayjpToken(configuration = configuration,
+                tokenApi = createApiClient(baseUrl = mockWebServer.url("/").toString(),
+                        callbackExecutor = CurrentThreadExecutor()))
+                .getToken("tok_5ca06b51685e001723a2c3b4aeb4")
+
+        try {
+            task.run()
+            fail()
+        } catch (e: IOException) {
+        }
+    }
+
+    companion object {
+
+        const val TOKEN_OK = """
+{
+  "card": {
+    "address_city": null,
+    "address_line1": null,
+    "address_line2": null,
+    "address_state": null,
+    "address_zip": null,
+    "address_zip_check": "unchecked",
+    "brand": "Visa",
+    "country": null,
+    "created": 1442290383,
+    "customer": null,
+    "cvc_check": "passed",
+    "exp_month": 2,
+    "exp_year": 2020,
+    "fingerprint": "e1d8225886e3a7211127df751c86787f",
+    "id": "car_e3ccd4e0959f45e7c75bacc4be90",
+    "livemode": false,
+    "metadata": {},
+    "last4": "4242",
+    "name": null,
+    "object": "card"
+  },
+  "created": 1442290383,
+  "id": "tok_5ca06b51685e001723a2c3b4aeb4",
+  "livemode": false,
+  "object": "token",
+  "used": false
+}
+        """
+
+        const val ERROR_AUTH = """
+{
+  "error": {
+    "message": "Invalid API Key: {0}",
+    "status": 401,
+    "type": "auth_error"
+  }
+}
+"""
+
+        const val ERROR_CARD_DECLINED = """
+{
+  "error": {
+    "code": "card_declined",
+    "message": "Card declined",
+    "status": 402,
+    "type": "card_error"
+  }
+}
+"""
+
+        const val ERROR_INVALID_ID = """
+{
+  "error": {
+    "code": "invalid_id",
+    "message": "No such token: tok_587af2665fdced4742e5fbb3ecfcaa",
+    "param": "id",
+    "status": 404,
+    "type": "client_error"
+  }
+}
+"""
+    }
+}

--- a/payjp/src/test/resources/robolectric.properties
+++ b/payjp/src/test/resources/robolectric.properties
@@ -1,0 +1,26 @@
+#
+#
+# Copyright (c) 2018 PAY.JP (https://pay.jp)
+# Copyright (c) 2018 BASE, Inc. (https://binc.jp/)
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
+sdk=26
+constants=jp.pay.android.BuildConfig

--- a/sample-java/src/main/java/com/example/payjp/samplejava/MainActivity.java
+++ b/sample-java/src/main/java/com/example/payjp/samplejava/MainActivity.java
@@ -24,19 +24,17 @@
 
 package com.example.payjp.samplejava;
 
+import android.os.Bundle;
+import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v7.app.AppCompatActivity;
-import android.os.Bundle;
 import android.util.Log;
 import android.view.View;
 import android.widget.ProgressBar;
 import android.widget.TextView;
 
-import org.jetbrains.annotations.NotNull;
-
 import jp.pay.android.PayjpToken;
 import jp.pay.android.Task;
-import jp.pay.android.model.CardBrand;
 import jp.pay.android.model.Token;
 
 public class MainActivity extends AppCompatActivity {
@@ -72,7 +70,7 @@ public class MainActivity extends AppCompatActivity {
                 }
 
                 @Override
-                public void onError(@NotNull Throwable throwable) {
+                public void onError(@NonNull Throwable throwable) {
                     Log.e("MainActivity", "failure creating token", throwable);
                     progressBar.setVisibility(View.GONE);
                     textTokenContent.setVisibility(View.VISIBLE);
@@ -96,7 +94,7 @@ public class MainActivity extends AppCompatActivity {
                 }
 
                 @Override
-                public void onError(@NotNull Throwable throwable) {
+                public void onError(@NonNull Throwable throwable) {
                     Log.e("MainActivity", "failure creating token", throwable);
                     progressBar.setVisibility(View.GONE);
                     textTokenContent.setVisibility(View.VISIBLE);


### PR DESCRIPTION
Fix #11 

If you want to know error code (cf. https://pay.jp/docs/api/#error ),
you can access as following.

```kotlin
PayjpToken.getInstance().createToken(
                requestCreditCard.cardNumber,
                requestCreditCard.cardCvc,
                requestCreditCard.cardExpirationMonth,
                requestCreditCard.cardExpirationYear)
                .enqueue(object : Task.Callback<Token> {
                    override fun onSuccess(data: Token) {
                        Log.i("MainActivity", "token => $data")
                    }

                    override fun onError(throwable: Throwable) {
                        if (throwable is PayjpApiException) {
                            val exception = throwable as PayjpApiException
                            Log.e("MainActivity", exception.httpStatusCode.toString()) // -> e.g. "402"
                            Log.e("MainActivity", exception.apiError.code) // -> e.g. "card_declined"
                            Log.e("MainActivity", exception.message) // -> e.g. "Card declined"
                            Log.e("MainActivity", exception.apiError.type) // -> e.g. "card_error"
                            Log.e("MainActivity", exception.cause::class.java) // -> retrofit2.HttpException
                            Log.e("MainActivity", exception.source) // -> e.g. "{ \"error\": { } }" (raw json)
                        }
                    }
                })
```
