### PR TITLE
Add card holder name.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ class SampleApplication: Application() {
 
 ```kotlin
 fun startCreateToken() {
-  PayjpToken.getInstance().createToken("4242424242424242", "123", "02", "2020")
+  PayjpToken.getInstance().createToken("4242424242424242", "123", "02", "2020", "TARO YAMADA")
       .enqueue(object : Task.Callback<Token> {
           override fun onSuccess(data: Token) {
               // you can charge with `Token#id`

--- a/payjp/src/main/kotlin/jp/pay/android/PayjpToken.kt
+++ b/payjp/src/main/kotlin/jp/pay/android/PayjpToken.kt
@@ -99,13 +99,15 @@ class PayjpToken internal constructor(
      * Create token from card.
      *
      */
+    @JvmOverloads
     fun createToken(
         number: String,
         cvc: String,
         expMonth: String,
-        expYear: String
+        expYear: String,
+        name: String? = null
     ): Task<Token> {
-        return tokenApi.createToken(authorization, number, cvc, expMonth, expYear)
+        return tokenApi.createToken(authorization, number, cvc, expMonth, expYear, name)
     }
 
     /**

--- a/payjp/src/main/kotlin/jp/pay/android/TokenApi.kt
+++ b/payjp/src/main/kotlin/jp/pay/android/TokenApi.kt
@@ -45,7 +45,8 @@ internal interface TokenApi {
         @Field("card[number]") number: String,
         @Field("card[cvc]") cvc: String,
         @Field("card[exp_month]") expMonth: String,
-        @Field("card[exp_year]") expYear: String
+        @Field("card[exp_year]") expYear: String,
+        @Field("card[name]") name: String?
     ): ResultCall<Token>
 
     @GET("tokens/{id}")

--- a/payjp/src/test/kotlin/jp/pay/android/PayjpTokenTest.kt
+++ b/payjp/src/test/kotlin/jp/pay/android/PayjpTokenTest.kt
@@ -73,7 +73,8 @@ class PayjpTokenTest {
         PayjpToken(configuration = configuration,
                 tokenApi = createApiClient(baseUrl = mockWebServer.url("/").toString(),
                         callbackExecutor = CurrentThreadExecutor()))
-                .createToken(number = "4242424242424242", cvc = "123", expMonth = "02", expYear = "2020")
+                .createToken(number = "4242424242424242",
+                        cvc = "123", expMonth = "02", expYear = "2020", name = "TARO YAMADA")
                 .run()
                 .let { token ->
                     assertEquals("tok_5ca06b51685e001723a2c3b4aeb4", token.id)
@@ -89,9 +90,28 @@ class PayjpTokenTest {
                     assertEquals("card%5Bnumber%5D=4242424242424242" +
                             "&card%5Bcvc%5D=123" +
                             "&card%5Bexp_month%5D=02" +
-                            "&card%5Bexp_year%5D=2020",
+                            "&card%5Bexp_year%5D=2020" +
+                            "&card%5Bname%5D=TARO%20YAMADA",
                             request.body.readString(Charset.forName("utf-8")))
                 }
+    }
+
+    @Test
+    fun createToken_ok_without_name() {
+        mockWebServer.enqueue(MockResponse().setResponseCode(200).setBody(TOKEN_OK))
+
+        PayjpToken(configuration = configuration,
+                tokenApi = createApiClient(baseUrl = mockWebServer.url("/").toString(),
+                        callbackExecutor = CurrentThreadExecutor()))
+                .createToken(number = "4242424242424242",
+                        cvc = "123", expMonth = "02", expYear = "2020")
+                .run()
+
+        assertEquals("card%5Bnumber%5D=4242424242424242" +
+                "&card%5Bcvc%5D=123" +
+                "&card%5Bexp_month%5D=02" +
+                "&card%5Bexp_year%5D=2020",
+                mockWebServer.takeRequest().body.readString(Charset.forName("utf-8")))
     }
 
     @Test
@@ -101,7 +121,8 @@ class PayjpTokenTest {
         val task = PayjpToken(configuration = configuration,
                 tokenApi = createApiClient(baseUrl = mockWebServer.url("/").toString(),
                         callbackExecutor = CurrentThreadExecutor()))
-                .createToken(number = "4242424242424242", cvc = "123", expMonth = "02", expYear = "2020")
+                .createToken(number = "4242424242424242",
+                        cvc = "123", expMonth = "02", expYear = "2020", name = "TARO YAMADA")
 
         try {
             task.run()
@@ -123,7 +144,8 @@ class PayjpTokenTest {
         val task = PayjpToken(configuration = configuration,
                 tokenApi = createApiClient(baseUrl = mockWebServer.url("/").toString(),
                         callbackExecutor = CurrentThreadExecutor()))
-                .createToken(number = "4000000000000002", cvc = "123", expMonth = "02", expYear = "2020")
+                .createToken(number = "4242424242424242",
+                        cvc = "123", expMonth = "02", expYear = "2020", name = "TARO YAMADA")
 
         try {
             task.run()
@@ -145,7 +167,8 @@ class PayjpTokenTest {
         val task = PayjpToken(configuration = configuration,
                 tokenApi = createApiClient(baseUrl = mockWebServer.url("/").toString(),
                         callbackExecutor = CurrentThreadExecutor()))
-                .createToken(number = "4242424242424242", cvc = "123", expMonth = "02", expYear = "2020")
+                .createToken(number = "4242424242424242",
+                        cvc = "123", expMonth = "02", expYear = "2020", name = "TARO YAMADA")
 
         try {
             task.run()

--- a/sample-java/build.gradle
+++ b/sample-java/build.gradle
@@ -71,5 +71,4 @@ dependencies {
     //implementation "jp.pay:payjp-android:0.1.0"
 
     implementation "com.android.support:appcompat-v7:$supportLib"
-    implementation 'com.android.support.constraint:constraint-layout:1.1.2'
 }

--- a/sample-java/src/main/java/com/example/payjp/samplejava/MainActivity.java
+++ b/sample-java/src/main/java/com/example/payjp/samplejava/MainActivity.java
@@ -44,6 +44,11 @@ public class MainActivity extends AppCompatActivity {
     private ProgressBar progressBar;
     private TextView textTokenId;
     private TextView textTokenContent;
+    private TextView textCardNumber;
+    private TextView textCardCvc;
+    private TextView textCardExpMonth;
+    private TextView textCardExpYear;
+    private TextView textCardName;
 
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
@@ -52,13 +57,23 @@ public class MainActivity extends AppCompatActivity {
         progressBar = findViewById(R.id.progress_bar);
         textTokenId = findViewById(R.id.text_token_id);
         textTokenContent = findViewById(R.id.text_token_content);
+        textCardNumber = findViewById(R.id.text_card_number);
+        textCardCvc = findViewById(R.id.text_card_cvc);
+        textCardExpMonth = findViewById(R.id.text_card_exp_month);
+        textCardExpYear = findViewById(R.id.text_card_exp_year);
+        textCardName = findViewById(R.id.text_card_name);
 
         findViewById(R.id.button_create_token).setOnClickListener(view -> {
             progressBar.setVisibility(View.VISIBLE);
             textTokenContent.setVisibility(View.INVISIBLE);
 
-            createToken = PayjpToken.getInstance().createToken("4242424242424242",
-                    "123", "02", "2020");
+            final String number = textCardNumber.getText().toString();
+            final String cvc = textCardCvc.getText().toString();
+            final String expMonth = textCardExpMonth.getText().toString();
+            final String expYear = textCardExpYear.getText().toString();
+            final String name = textCardName.getText().toString();
+
+            createToken = PayjpToken.getInstance().createToken(number, cvc, expMonth, expYear, name);
             createToken.enqueue(new Task.Callback<Token>() {
                 @Override
                 public void onSuccess(Token data) {

--- a/sample-java/src/main/java/com/example/payjp/samplejava/MainActivity.java
+++ b/sample-java/src/main/java/com/example/payjp/samplejava/MainActivity.java
@@ -80,6 +80,7 @@ public class MainActivity extends AppCompatActivity {
                     Log.i("MainActivity", "token => " + data);
                     textTokenId.setText(data.getId());
                     progressBar.setVisibility(View.GONE);
+                    textTokenContent.setText("The token has created.");
                     textTokenContent.setVisibility(View.VISIBLE);
                 }
 

--- a/sample-java/src/main/res/layout/activity_main.xml
+++ b/sample-java/src/main/res/layout/activity_main.xml
@@ -21,114 +21,121 @@
   ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
   ~ SOFTWARE.
   -->
-
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:orientation="vertical"
-    android:padding="16dp"
-    tools:ignore="HardcodedText">
-
-    <EditText
-        android:id="@+id/text_card_number"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:hint="card number"
-        android:inputType="number"
-        android:text="4242424242424242"
-        android:textSize="14sp" />
-
-    <EditText
-        android:id="@+id/text_card_cvc"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:hint="card cvc"
-        android:inputType="number"
-        android:text="123"
-        android:textSize="14sp" />
-
-    <EditText
-        android:id="@+id/text_card_exp_month"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:hint="card exp month"
-        android:inputType="number"
-        android:text="12"
-        android:textSize="14sp" />
-
-    <EditText
-        android:id="@+id/text_card_exp_year"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:hint="card exp year"
-        android:inputType="number"
-        android:text="2020"
-        android:textSize="14sp" />
-
-    <EditText
-        android:id="@+id/text_card_name"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:hint="card name"
-        android:inputType="text"
-        android:text="TARO YAMADA"
-        android:textSize="14sp" />
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+            xmlns:tools="http://schemas.android.com/tools"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+>
 
     <LinearLayout
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="16dp"
-        android:orientation="horizontal">
-
-        <Button
-            android:id="@+id/button_create_token"
-            style="@style/Widget.AppCompat.Button"
-            android:layout_width="0dp"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_weight="1"
-            android:text="generate token" />
+            android:orientation="vertical"
+            android:padding="16dp"
+            tools:ignore="HardcodedText">
 
-        <Button
-            android:id="@+id/button_get_token"
-            style="@style/Widget.AppCompat.Button"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_weight="1"
-            android:text="get token by id" />
+        <EditText
+                android:id="@+id/text_card_number"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="card number"
+                android:inputType="number"
+                android:text="4242424242424242"
+                android:textSize="14sp"/>
+
+        <EditText
+                android:id="@+id/text_card_cvc"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="card cvc"
+                android:inputType="number"
+                android:text="123"
+                android:textSize="14sp"/>
+
+        <EditText
+                android:id="@+id/text_card_exp_month"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="card exp month"
+                android:inputType="number"
+                android:text="12"
+                android:textSize="14sp"/>
+
+        <EditText
+                android:id="@+id/text_card_exp_year"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="card exp year"
+                android:inputType="number"
+                android:text="2020"
+                android:textSize="14sp"/>
+
+        <EditText
+                android:id="@+id/text_card_name"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="card name"
+                android:inputType="text"
+                android:text="TARO YAMADA"
+                android:textSize="14sp"/>
+
+        <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="16dp"
+                android:orientation="horizontal">
+
+            <Button
+                    android:id="@+id/button_create_token"
+                    style="@style/Widget.AppCompat.Button"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:text="generate token"/>
+
+            <Button
+                    android:id="@+id/button_get_token"
+                    style="@style/Widget.AppCompat.Button"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:text="get token by id"/>
+
+        </LinearLayout>
+
+        <EditText
+                android:id="@+id/text_token_id"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="16dp"
+                android:clickable="false"
+                android:focusable="false"
+                android:focusableInTouchMode="false"
+                android:hint="token ID (after created available)"
+                android:inputType="text"
+                android:longClickable="false"
+                android:textSize="14sp"/>
+
+        <TextView
+                android:id="@+id/text_token_content"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="8dp"
+                android:layout_marginEnd="8dp"
+                android:layout_marginStart="8dp"
+                android:layout_marginTop="16dp"
+                android:text="The token will be shown here."/>
+
+        <ProgressBar
+                android:id="@+id/progress_bar"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_horizontal"
+                android:layout_marginEnd="8dp"
+                android:layout_marginStart="8dp"
+                android:visibility="gone"/>
 
     </LinearLayout>
 
-    <EditText
-        android:id="@+id/text_token_id"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="16dp"
-        android:clickable="false"
-        android:focusable="false"
-        android:focusableInTouchMode="false"
-        android:hint="token ID (after created available)"
-        android:inputType="text"
-        android:longClickable="false"
-        android:textSize="14sp" />
 
-    <TextView
-        android:id="@+id/text_token_content"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginBottom="8dp"
-        android:layout_marginEnd="8dp"
-        android:layout_marginStart="8dp"
-        android:layout_marginTop="16dp"
-        android:text="The token will be shown here." />
-
-    <ProgressBar
-        android:id="@+id/progress_bar"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="center_horizontal"
-        android:layout_marginEnd="8dp"
-        android:layout_marginStart="8dp"
-        android:visibility="gone" />
-
-</LinearLayout>
+</ScrollView>

--- a/sample-java/src/main/res/layout/activity_main.xml
+++ b/sample-java/src/main/res/layout/activity_main.xml
@@ -22,84 +22,113 @@
   ~ SOFTWARE.
   -->
 
-<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:padding="16dp"
     tools:ignore="HardcodedText">
 
-    <Button
-        android:id="@+id/button_create_token"
-        style="@style/Widget.AppCompat.Button"
-        android:layout_width="wrap_content"
+    <EditText
+        android:id="@+id/text_card_number"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="card number"
+        android:inputType="number"
+        android:text="4242424242424242"
+        android:textSize="14sp" />
+
+    <EditText
+        android:id="@+id/text_card_cvc"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="card cvc"
+        android:inputType="number"
+        android:text="123"
+        android:textSize="14sp" />
+
+    <EditText
+        android:id="@+id/text_card_exp_month"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="card exp month"
+        android:inputType="number"
+        android:text="12"
+        android:textSize="14sp" />
+
+    <EditText
+        android:id="@+id/text_card_exp_year"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="card exp year"
+        android:inputType="number"
+        android:text="2020"
+        android:textSize="14sp" />
+
+    <EditText
+        android:id="@+id/text_card_name"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="card name"
+        android:inputType="text"
+        android:text="TARO YAMADA"
+        android:textSize="14sp" />
+
+    <LinearLayout
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginTop="16dp"
-        android:layout_marginStart="8dp"
-        android:layout_marginLeft="8dp"
-        android:text="generate token"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        />
+        android:orientation="horizontal">
+
+        <Button
+            android:id="@+id/button_create_token"
+            style="@style/Widget.AppCompat.Button"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="generate token" />
+
+        <Button
+            android:id="@+id/button_get_token"
+            style="@style/Widget.AppCompat.Button"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="get token by id" />
+
+    </LinearLayout>
 
     <EditText
         android:id="@+id/text_token_id"
-        android:layout_width="0dp"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginEnd="8dp"
-        android:layout_marginStart="8dp"
         android:layout_marginTop="16dp"
-        android:hint="token ID (after created available)"
-        android:textSize="14sp"
+        android:clickable="false"
         android:focusable="false"
         android:focusableInTouchMode="false"
-        android:clickable="false"
+        android:hint="token ID (after created available)"
+        android:inputType="text"
         android:longClickable="false"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHorizontal_bias="0.0"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/button_create_token" />
+        android:textSize="14sp" />
 
     <TextView
         android:id="@+id/text_token_content"
-        android:layout_width="0dp"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginBottom="8dp"
+        android:layout_marginEnd="8dp"
+        android:layout_marginStart="8dp"
         android:layout_marginTop="16dp"
-        android:layout_marginEnd="8dp"
-        android:layout_marginStart="8dp"
-        android:text="The token will be shown here."
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHorizontal_bias="0"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/text_token_id"
-        app:layout_constraintVertical_bias="0" />
-
-    <Button
-        android:id="@+id/button_get_token"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginEnd="8dp"
-        android:layout_marginStart="8dp"
-        android:text="get token by token id"
-        app:layout_constraintBottom_toBottomOf="@+id/button_create_token"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHorizontal_bias="0"
-        app:layout_constraintStart_toEndOf="@+id/button_create_token"
-        app:layout_constraintTop_toTopOf="@+id/button_create_token"
-        app:layout_constraintVertical_bias="0.0" />
+        android:text="The token will be shown here." />
 
     <ProgressBar
         android:id="@+id/progress_bar"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:layout_gravity="center_horizontal"
         android:layout_marginEnd="8dp"
         android:layout_marginStart="8dp"
-        app:layout_constraintTop_toTopOf="@id/text_token_content"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        android:visibility="gone"
-        />
+        android:visibility="gone" />
 
-</android.support.constraint.ConstraintLayout>
+</LinearLayout>

--- a/sample-kotlin/build.gradle
+++ b/sample-kotlin/build.gradle
@@ -65,5 +65,4 @@ dependencies {
 
     implementation"org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation "com.android.support:appcompat-v7:$supportLib"
-    implementation 'com.android.support.constraint:constraint-layout:1.1.2'
 }

--- a/sample-kotlin/src/main/kotlin/com/example/payjp/samplekotlin/MainActivity.kt
+++ b/sample-kotlin/src/main/kotlin/com/example/payjp/samplekotlin/MainActivity.kt
@@ -65,6 +65,7 @@ class MainActivity : AppCompatActivity() {
                 override fun onSuccess(data: Token) {
                     Log.i("MainActivity", "token => $data")
                     text_token_id.setText(data.id)
+                    text_token_content.text = "The token has created."
                     progress_bar.visibility = View.GONE
                     text_token_content.visibility = View.VISIBLE
                 }

--- a/sample-kotlin/src/main/kotlin/com/example/payjp/samplekotlin/MainActivity.kt
+++ b/sample-kotlin/src/main/kotlin/com/example/payjp/samplekotlin/MainActivity.kt
@@ -29,7 +29,16 @@ import android.view.View
 import jp.pay.android.PayjpToken
 import jp.pay.android.Task
 import jp.pay.android.model.Token
-import kotlinx.android.synthetic.main.activity_main.*
+import kotlinx.android.synthetic.main.activity_main.button_get_token
+import kotlinx.android.synthetic.main.activity_main.button_create_token
+import kotlinx.android.synthetic.main.activity_main.progress_bar
+import kotlinx.android.synthetic.main.activity_main.text_card_exp_month
+import kotlinx.android.synthetic.main.activity_main.text_card_exp_year
+import kotlinx.android.synthetic.main.activity_main.text_card_cvc
+import kotlinx.android.synthetic.main.activity_main.text_card_number
+import kotlinx.android.synthetic.main.activity_main.text_card_name
+import kotlinx.android.synthetic.main.activity_main.text_token_id
+import kotlinx.android.synthetic.main.activity_main.text_token_content
 
 class MainActivity : AppCompatActivity() {
 
@@ -44,8 +53,14 @@ class MainActivity : AppCompatActivity() {
             progress_bar.visibility = View.VISIBLE
             text_token_content.visibility = View.INVISIBLE
             // create token
-            createToken = PayjpToken.getInstance().createToken("4242424242424242",
-                    "123", "02", "2020")
+            val number = text_card_number.text.toString()
+            val cvc = text_card_cvc.text.toString()
+            val expMonth = text_card_exp_month.text.toString()
+            val expYear = text_card_exp_year.text.toString()
+            val name = text_card_name.text.toString()
+
+            createToken = PayjpToken.getInstance().createToken(number = number, cvc = cvc,
+                    expMonth = expMonth, expYear = expYear, name = name)
             createToken?.enqueue(object : Task.Callback<Token> {
                 override fun onSuccess(data: Token) {
                     Log.i("MainActivity", "token => $data")

--- a/sample-kotlin/src/main/res/layout/activity_main.xml
+++ b/sample-kotlin/src/main/res/layout/activity_main.xml
@@ -21,113 +21,120 @@
   ~ SOFTWARE.
   -->
 
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:orientation="vertical"
-    android:padding="16dp"
-    tools:ignore="HardcodedText">
-
-    <EditText
-        android:id="@+id/text_card_number"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:hint="card number"
-        android:inputType="number"
-        android:text="4242424242424242"
-        android:textSize="14sp" />
-
-    <EditText
-        android:id="@+id/text_card_cvc"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:hint="card cvc"
-        android:inputType="number"
-        android:text="123"
-        android:textSize="14sp" />
-
-    <EditText
-        android:id="@+id/text_card_exp_month"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:hint="card exp month"
-        android:inputType="number"
-        android:text="12"
-        android:textSize="14sp" />
-
-    <EditText
-        android:id="@+id/text_card_exp_year"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:hint="card exp year"
-        android:inputType="number"
-        android:text="2020"
-        android:textSize="14sp" />
-
-    <EditText
-        android:id="@+id/text_card_name"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:hint="card name"
-        android:inputType="text"
-        android:text="TARO YAMADA"
-        android:textSize="14sp" />
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+            xmlns:tools="http://schemas.android.com/tools"
+            android:layout_height="match_parent"
+            android:layout_width="match_parent">
 
     <LinearLayout
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="16dp"
-        android:orientation="horizontal">
-
-        <Button
-            android:id="@+id/button_create_token"
-            style="@style/Widget.AppCompat.Button"
-            android:layout_width="0dp"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_weight="1"
-            android:text="generate token" />
+            android:orientation="vertical"
+            android:padding="16dp"
+            tools:ignore="HardcodedText">
 
-        <Button
-            android:id="@+id/button_get_token"
-            style="@style/Widget.AppCompat.Button"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_weight="1"
-            android:text="get token by id" />
+        <EditText
+                android:id="@+id/text_card_number"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="card number"
+                android:inputType="number"
+                android:text="4242424242424242"
+                android:textSize="14sp" />
+
+        <EditText
+                android:id="@+id/text_card_cvc"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="card cvc"
+                android:inputType="number"
+                android:text="123"
+                android:textSize="14sp" />
+
+        <EditText
+                android:id="@+id/text_card_exp_month"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="card exp month"
+                android:inputType="number"
+                android:text="12"
+                android:textSize="14sp" />
+
+        <EditText
+                android:id="@+id/text_card_exp_year"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="card exp year"
+                android:inputType="number"
+                android:text="2020"
+                android:textSize="14sp" />
+
+        <EditText
+                android:id="@+id/text_card_name"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="card name"
+                android:inputType="text"
+                android:text="TARO YAMADA"
+                android:textSize="14sp" />
+
+        <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="16dp"
+                android:orientation="horizontal">
+
+            <Button
+                    android:id="@+id/button_create_token"
+                    style="@style/Widget.AppCompat.Button"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:text="generate token" />
+
+            <Button
+                    android:id="@+id/button_get_token"
+                    style="@style/Widget.AppCompat.Button"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:text="get token by id" />
+
+        </LinearLayout>
+
+        <EditText
+                android:id="@+id/text_token_id"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="16dp"
+                android:clickable="false"
+                android:focusable="false"
+                android:focusableInTouchMode="false"
+                android:hint="token ID (after created available)"
+                android:inputType="text"
+                android:longClickable="false"
+                android:textSize="14sp" />
+
+        <TextView
+                android:id="@+id/text_token_content"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="8dp"
+                android:layout_marginEnd="8dp"
+                android:layout_marginStart="8dp"
+                android:layout_marginTop="16dp"
+                android:text="The token will be shown here." />
+
+        <ProgressBar
+                android:id="@+id/progress_bar"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_horizontal"
+                android:layout_marginEnd="8dp"
+                android:layout_marginStart="8dp"
+                android:visibility="gone" />
 
     </LinearLayout>
 
-    <EditText
-        android:id="@+id/text_token_id"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="16dp"
-        android:clickable="false"
-        android:focusable="false"
-        android:focusableInTouchMode="false"
-        android:hint="token ID (after created available)"
-        android:inputType="text"
-        android:longClickable="false"
-        android:textSize="14sp" />
 
-    <TextView
-        android:id="@+id/text_token_content"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginBottom="8dp"
-        android:layout_marginEnd="8dp"
-        android:layout_marginStart="8dp"
-        android:layout_marginTop="16dp"
-        android:text="The token will be shown here." />
-
-    <ProgressBar
-        android:id="@+id/progress_bar"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="center_horizontal"
-        android:layout_marginEnd="8dp"
-        android:layout_marginStart="8dp"
-        android:visibility="gone" />
-
-</LinearLayout>
+</ScrollView>

--- a/sample-kotlin/src/main/res/layout/activity_main.xml
+++ b/sample-kotlin/src/main/res/layout/activity_main.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
   ~
   ~ Copyright (c) 2018 PAY, Inc.
   ~
@@ -22,83 +21,113 @@
   ~ SOFTWARE.
   -->
 
-<android.support.constraint.ConstraintLayout xmlns:app="http://schemas.android.com/apk/res-auto"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:padding="16dp"
     tools:ignore="HardcodedText">
 
-    <Button
-        android:id="@+id/button_create_token"
-        style="@style/Widget.AppCompat.Button"
-        android:layout_width="wrap_content"
+    <EditText
+        android:id="@+id/text_card_number"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="card number"
+        android:inputType="number"
+        android:text="4242424242424242"
+        android:textSize="14sp" />
+
+    <EditText
+        android:id="@+id/text_card_cvc"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="card cvc"
+        android:inputType="number"
+        android:text="123"
+        android:textSize="14sp" />
+
+    <EditText
+        android:id="@+id/text_card_exp_month"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="card exp month"
+        android:inputType="number"
+        android:text="12"
+        android:textSize="14sp" />
+
+    <EditText
+        android:id="@+id/text_card_exp_year"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="card exp year"
+        android:inputType="number"
+        android:text="2020"
+        android:textSize="14sp" />
+
+    <EditText
+        android:id="@+id/text_card_name"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="card name"
+        android:inputType="text"
+        android:text="TARO YAMADA"
+        android:textSize="14sp" />
+
+    <LinearLayout
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginTop="16dp"
-        android:layout_marginStart="8dp"
-        android:layout_marginLeft="8dp"
-        android:text="generate token"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        android:orientation="horizontal">
+
+        <Button
+            android:id="@+id/button_create_token"
+            style="@style/Widget.AppCompat.Button"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="generate token" />
+
+        <Button
+            android:id="@+id/button_get_token"
+            style="@style/Widget.AppCompat.Button"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="get token by id" />
+
+    </LinearLayout>
 
     <EditText
         android:id="@+id/text_token_id"
-        android:layout_width="0dp"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginEnd="8dp"
-        android:layout_marginStart="8dp"
         android:layout_marginTop="16dp"
-        android:hint="token ID (after created available)"
-        android:textSize="14sp"
+        android:clickable="false"
         android:focusable="false"
         android:focusableInTouchMode="false"
-        android:clickable="false"
+        android:hint="token ID (after created available)"
+        android:inputType="text"
         android:longClickable="false"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHorizontal_bias="0.0"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/button_create_token" />
+        android:textSize="14sp" />
 
     <TextView
         android:id="@+id/text_token_content"
-        android:layout_width="0dp"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginBottom="8dp"
+        android:layout_marginEnd="8dp"
+        android:layout_marginStart="8dp"
         android:layout_marginTop="16dp"
-        android:layout_marginEnd="8dp"
-        android:layout_marginStart="8dp"
-        android:text="The token will be shown here."
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHorizontal_bias="0"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/text_token_id"
-        app:layout_constraintVertical_bias="0" />
-
-    <Button
-        android:id="@+id/button_get_token"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginEnd="8dp"
-        android:layout_marginStart="8dp"
-        android:text="get token by token id"
-        app:layout_constraintBottom_toBottomOf="@+id/button_create_token"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHorizontal_bias="0"
-        app:layout_constraintStart_toEndOf="@+id/button_create_token"
-        app:layout_constraintTop_toTopOf="@+id/button_create_token"
-        app:layout_constraintVertical_bias="0.0" />
+        android:text="The token will be shown here." />
 
     <ProgressBar
         android:id="@+id/progress_bar"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:layout_gravity="center_horizontal"
         android:layout_marginEnd="8dp"
         android:layout_marginStart="8dp"
-        app:layout_constraintTop_toTopOf="@id/text_token_content"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        android:visibility="gone"
-        />
+        android:visibility="gone" />
 
-</android.support.constraint.ConstraintLayout>
+</LinearLayout>


### PR DESCRIPTION
In Token API, we can pass card holder name as card[name] but payjp-android doesn' t.

cf. https://pay.jp/docs/api/#%E3%83%88%E3%83%BC%E3%82%AF%E3%83%B3%E3%82%92%E4%BD%9C%E6%88%90 (API Reference)

This PR added argument for card holder name as following.

```kotlin
fun startCreateToken() {
  PayjpToken.getInstance().createToken("4242424242424242", "123", "02", "2020", "TARO YAMADA")
      .enqueue(object : Task.Callback<Token> {
          override fun onSuccess(data: Token) {
              // you can charge with `Token#id`
              Log.i("MainActivity", "token => $data")
          }

          override fun onError(throwable: Throwable) {
              Log.e("MainActivity", "failure creating token", throwable)
          }
      })
}
```

`name` is null by default. So it will not break old version api.

related => https://github.com/payjp/payjp-ios/pull/10