### PR TITLE
Migrate AndroidX.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ android:
   components:
     - tools
     - platform-tools
-    - android-27
+    - android-28
     - extra-google-m2repository
     - extra-android-m2repository
   licenses:

--- a/build.gradle
+++ b/build.gradle
@@ -54,7 +54,7 @@ subprojects {
 ext {
 
     minSdkVersion = 14
-    targetSdkVersion = 27
+    sdkVersion = 28
 
     supportLib = "27.1.1"
     okHttp = "3.9.0"

--- a/gradle.properties
+++ b/gradle.properties
@@ -28,6 +28,11 @@ org.gradle.parallel=true
 org.gradle.daemon=true
 org.gradle.configureondemand=true
 
+# android
+
+android.useAndroidX=true
+android.enableJetifier=true
+
 # Upload config
 
 GROUP=jp.pay

--- a/payjp/build.gradle
+++ b/payjp/build.gradle
@@ -48,8 +48,6 @@ android {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 
-    implementation "com.android.support:appcompat-v7:$supportLib"
-
     implementation "com.squareup.okhttp3:okhttp:$okHttp"
     implementation "com.squareup.okhttp3:logging-interceptor:$okHttp"
     implementation "com.squareup.moshi:moshi:$moshi"

--- a/payjp/build.gradle
+++ b/payjp/build.gradle
@@ -33,7 +33,7 @@ android {
         minSdkVersion rootProject.minSdkVersion
 
         consumerProguardFiles 'consumer-proguard-rules.pro'
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 
     sourceSets.all {

--- a/payjp/build.gradle
+++ b/payjp/build.gradle
@@ -27,10 +27,10 @@ apply plugin: 'kotlin-kapt'
 apply plugin: 'org.jetbrains.dokka-android'
 
 android {
-    compileSdkVersion 27
+    compileSdkVersion rootProject.sdkVersion
 
     defaultConfig {
-        minSdkVersion rootProject.ext.minSdkVersion
+        minSdkVersion rootProject.minSdkVersion
 
         consumerProguardFiles 'consumer-proguard-rules.pro'
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"

--- a/sample-java/build.gradle
+++ b/sample-java/build.gradle
@@ -70,5 +70,5 @@ dependencies {
     implementation project(':payjp')
     //implementation "jp.pay:payjp-android:0.1.0"
 
-    implementation "com.android.support:appcompat-v7:$supportLib"
+    implementation 'androidx.appcompat:appcompat:1.0.2'
 }

--- a/sample-java/build.gradle
+++ b/sample-java/build.gradle
@@ -24,12 +24,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 27
+    compileSdkVersion rootProject.sdkVersion
 
     defaultConfig {
         applicationId "com.example.payjp.samplejava"
-        minSdkVersion rootProject.ext.minSdkVersion
-        targetSdkVersion rootProject.ext.targetSdkVersion
+        minSdkVersion rootProject.minSdkVersion
+        targetSdkVersion rootProject.sdkVersion
         versionCode 1
         versionName "1.0.0"
     }

--- a/sample-java/src/main/java/com/example/payjp/samplejava/MainActivity.java
+++ b/sample-java/src/main/java/com/example/payjp/samplejava/MainActivity.java
@@ -24,9 +24,9 @@
 package com.example.payjp.samplejava;
 
 import android.os.Bundle;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
-import android.support.v7.app.AppCompatActivity;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AppCompatActivity;
 import android.util.Log;
 import android.view.View;
 import android.widget.ProgressBar;

--- a/sample-kotlin/build.gradle
+++ b/sample-kotlin/build.gradle
@@ -26,12 +26,12 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 
 android {
-    compileSdkVersion 27
+    compileSdkVersion rootProject.sdkVersion
 
     defaultConfig {
         applicationId "com.example.payjp.samplekotlin"
-        minSdkVersion rootProject.ext.minSdkVersion
-        targetSdkVersion rootProject.ext.targetSdkVersion
+        minSdkVersion rootProject.minSdkVersion
+        targetSdkVersion rootProject.sdkVersion
         versionCode 1
         versionName "1.0.0"
     }

--- a/sample-kotlin/build.gradle
+++ b/sample-kotlin/build.gradle
@@ -64,5 +64,5 @@ dependencies {
     //implementation "jp.pay:payjp-android:0.1.0"
 
     implementation"org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation "com.android.support:appcompat-v7:$supportLib"
+    implementation 'androidx.appcompat:appcompat:1.0.2'
 }

--- a/sample-kotlin/src/main/kotlin/com/example/payjp/samplekotlin/MainActivity.kt
+++ b/sample-kotlin/src/main/kotlin/com/example/payjp/samplekotlin/MainActivity.kt
@@ -23,7 +23,7 @@
 package com.example.payjp.samplekotlin
 
 import android.os.Bundle
-import android.support.v7.app.AppCompatActivity
+import androidx.appcompat.app.AppCompatActivity
 import android.util.Log
 import android.view.View
 import jp.pay.android.PayjpToken


### PR DESCRIPTION
Fix #19 
- remove unused `appcompat`.
- migrate androidx (only test and sample app).
