### PR TITLE
AGP 4.1.1 kotlin 1.4.20

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,13 +24,13 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.4.10'
+    ext.kotlin_version = '1.4.20'
     repositories {
         google()
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.0'
+        classpath 'com.android.tools.build:gradle:4.1.1'
         classpath 'com.google.gms:google-services:4.3.4'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }

--- a/payjp-android-cardform/build.gradle
+++ b/payjp-android-cardform/build.gradle
@@ -24,18 +24,14 @@
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-kapt'
+apply plugin: 'kotlin-parcelize'
 apply plugin: 'org.jetbrains.dokka'
-apply plugin: 'kotlin-android-extensions'
 
 apply from: rootProject.file('gradle/gradle-mvn-push.gradle')
 apply from: rootProject.file("gradle/dependencies-test.gradle")
 apply from: rootProject.file("gradle/android-common.gradle")
 
 android {
-    androidExtensions {
-        features = ["parcelize"]
-    }
-
     buildFeatures {
         viewBinding = true
     }

--- a/payjp-android-core/build.gradle
+++ b/payjp-android-core/build.gradle
@@ -23,8 +23,8 @@
 
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlin-kapt'
+apply plugin: 'kotlin-parcelize'
 apply plugin: 'org.jetbrains.dokka'
 
 apply from: rootProject.file('gradle/gradle-mvn-push.gradle')
@@ -37,9 +37,6 @@ android {
         buildConfigField "String", "VERSION_NAME", "\"$VERSION_NAME\""
     }
 
-    androidExtensions {
-        features = ["parcelize"]
-    }
     buildFeatures {
         buildConfig = true
     }

--- a/payjp-android-core/src/main/kotlin/jp/pay/android/model/Card.kt
+++ b/payjp-android-core/src/main/kotlin/jp/pay/android/model/Card.kt
@@ -26,7 +26,7 @@ import android.os.Bundle
 import android.os.Parcelable
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 import java.util.Date
 
 /**

--- a/payjp-android-core/src/main/kotlin/jp/pay/android/model/CardBrand.kt
+++ b/payjp-android-core/src/main/kotlin/jp/pay/android/model/CardBrand.kt
@@ -26,7 +26,7 @@ import android.os.Parcelable
 import com.squareup.moshi.FromJson
 import com.squareup.moshi.JsonDataException
 import com.squareup.moshi.ToJson
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 /**
  * CardBrand

--- a/payjp-android-core/src/main/kotlin/jp/pay/android/model/ThreeDSecureStatus.kt
+++ b/payjp-android-core/src/main/kotlin/jp/pay/android/model/ThreeDSecureStatus.kt
@@ -26,7 +26,7 @@ import android.os.Parcelable
 import com.squareup.moshi.FromJson
 import com.squareup.moshi.JsonDataException
 import com.squareup.moshi.ToJson
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 import java.util.Locale
 
 /**

--- a/payjp-android-core/src/main/kotlin/jp/pay/android/model/ThreeDSecureToken.kt
+++ b/payjp-android-core/src/main/kotlin/jp/pay/android/model/ThreeDSecureToken.kt
@@ -25,7 +25,7 @@ package jp.pay.android.model
 import android.net.Uri
 import android.os.Parcelable
 import jp.pay.android.PayjpConstants
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 /**
  * 3-D Secure token object

--- a/payjp-android-core/src/main/kotlin/jp/pay/android/model/Token.kt
+++ b/payjp-android-core/src/main/kotlin/jp/pay/android/model/Token.kt
@@ -24,7 +24,7 @@ package jp.pay.android.model
 
 import android.os.Parcelable
 import com.squareup.moshi.JsonClass
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 import java.util.Date
 
 /**

--- a/payjp-android-coroutine/build.gradle
+++ b/payjp-android-coroutine/build.gradle
@@ -23,7 +23,6 @@
 
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlin-kapt'
 apply plugin: 'org.jetbrains.dokka'
 


### PR DESCRIPTION
- AGP 4.1.0 -> 4.1.1
- kotlin 1.4.10 -> 1.4.20
- Use `kotlin-parcelize` plugin instead of `kotlin-android-extensions` (deprecated).

https://android-developers.googleblog.com/2020/11/the-future-of-kotlin-android-extensions.html
https://blog.jetbrains.com/kotlin/2020/11/kotlin-1-4-20-released/