### PR TITLE
Card、Tokenのモデル定義にobjectキーを追加

### DIFF
--- a/common-test/src/main/java/jp/pay/android/TestStubs.kt
+++ b/common-test/src/main/java/jp/pay/android/TestStubs.kt
@@ -52,7 +52,8 @@ object TestStubs {
         customer: String? = null,
         cvcCheck: String = "unchecked",
         metadata: Bundle = Bundle.EMPTY,
-        threeDSecureStatus: ThreeDSecureStatus? = null
+        threeDSecureStatus: ThreeDSecureStatus? = null,
+        `object`: String = "card"
     ): Card = Card(
         id = id,
         name = name,
@@ -73,7 +74,8 @@ object TestStubs {
         customer = customer,
         cvcCheck = cvcCheck,
         metadata = metadata,
-        threeDSecureStatus = threeDSecureStatus
+        threeDSecureStatus = threeDSecureStatus,
+        `object` = `object`
     )
 
     fun newToken(
@@ -82,12 +84,14 @@ object TestStubs {
         card: Card = newCard(seed),
         livemode: Boolean = card.livemode,
         used: Boolean = false,
-        created: Date = Date(seed.toLong())
+        created: Date = Date(seed.toLong()),
+        `object`: String = "token"
     ): Token = Token(
         id = id,
         card = card,
         livemode = livemode,
         used = used,
-        created = created
+        created = created,
+        `object` = `object`
     )
 }

--- a/payjp-android-core/src/main/kotlin/jp/pay/android/model/Card.kt
+++ b/payjp-android-core/src/main/kotlin/jp/pay/android/model/Card.kt
@@ -57,7 +57,8 @@ data class Card(
     val customer: String?,
     @Json(name = "cvc_check") val cvcCheck: String,
     val metadata: Bundle,
-    @Json(name = "three_d_secure_status") val threeDSecureStatus: ThreeDSecureStatus?
+    @Json(name = "three_d_secure_status") val threeDSecureStatus: ThreeDSecureStatus?,
+    val `object`: String
 ) : Parcelable {
 
     override fun hashCode(): Int = id.hashCode()

--- a/payjp-android-core/src/main/kotlin/jp/pay/android/model/Token.kt
+++ b/payjp-android-core/src/main/kotlin/jp/pay/android/model/Token.kt
@@ -39,7 +39,8 @@ data class Token(
     val created: Date,
     val id: String,
     val livemode: Boolean,
-    val used: Boolean
+    val used: Boolean,
+    val `object`: String
 ) : Parcelable {
 
     override fun hashCode(): Int = id.hashCode()

--- a/payjp-android-core/src/test/kotlin/jp/pay/android/model/SerializersKtTest.kt
+++ b/payjp-android-core/src/test/kotlin/jp/pay/android/model/SerializersKtTest.kt
@@ -61,7 +61,8 @@ class SerializersKtTest {
                 putString("meta_a", "a")
                 putBoolean("meta_true", true)
             },
-            threeDSecureStatus = ThreeDSecureStatus.VERIFIED
+            threeDSecureStatus = ThreeDSecureStatus.VERIFIED,
+            `object` = "card"
         )
     }
 
@@ -86,7 +87,8 @@ class SerializersKtTest {
             card = cardFulFilled,
             livemode = true,
             used = false,
-            created = Date(1577804400L * 1000)
+            created = Date(1577804400L * 1000),
+            `object` = "token"
         )
     }
 


### PR DESCRIPTION
cardやtokenのJSONに含まれるキー `object` がSDK側のモデルで未定義なので、 https://github.com/payjp/payjp-flutter-plugin でnonnull定義のobjectがnullになってしまう問題を解決するために object の定義を追加します。