### PR TITLE
3Dセキュアの認証をWebで実施した後にアプリに戻れない問題を修正

### DIFF
--- a/payjp-android-verifier/src/main/AndroidManifest.xml
+++ b/payjp-android-verifier/src/main/AndroidManifest.xml
@@ -24,8 +24,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <queries>
         <intent>
-            <action android:name="android.intent.action.VIEW" />
-            <data android:scheme="https" />
+            <action android:name="android.support.customtabs.action.CustomTabsService" />
         </intent>
     </queries>
 

--- a/payjp-android-verifier/src/main/AndroidManifest.xml
+++ b/payjp-android-verifier/src/main/AndroidManifest.xml
@@ -22,6 +22,12 @@
   -->
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <queries>
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <data android:scheme="https" />
+        </intent>
+    </queries>
 
     <application>
 

--- a/payjp-android-verifier/src/main/kotlin/jp/pay/android/verifier/ui/PayjpWebActivity.kt
+++ b/payjp-android-verifier/src/main/kotlin/jp/pay/android/verifier/ui/PayjpWebActivity.kt
@@ -140,7 +140,7 @@ class PayjpWebActivity : AppCompatActivity(), LifecycleObserver {
                     swipeRefresh = binding.swipeRefresh
                 )
             )
-            addOnFinishedLoadState { _, url ->
+            addOnStartedLoadState { _, url ->
                 if (url.startsWith(callbackUri.toString())) {
                     logger.d("url matches with callbackUri $url")
                     redirectWithResult(Uri.parse(url))

--- a/payjp-android-verifier/src/main/kotlin/jp/pay/android/verifier/ui/VerifierWebView.kt
+++ b/payjp-android-verifier/src/main/kotlin/jp/pay/android/verifier/ui/VerifierWebView.kt
@@ -99,8 +99,8 @@ internal class VerifierWebView @JvmOverloads constructor(
         loadStateWatchers.add(loadStateWatcher)
     }
 
-    fun addOnFinishedLoadState(onFinished: (webView: WebView, url: String) -> Unit) {
-        addLoadStateWatcher(onFinished = onFinished)
+    fun addOnStartedLoadState(onStarted: (webView: WebView, url: String) -> Unit) {
+        addLoadStateWatcher(onStarted = onStarted)
     }
 
     fun addLoadStateWatcher(


### PR DESCRIPTION
1. Android 11以降でChromeが開かなくなっているのを修正しました。
  - https://developer.android.com/training/package-visibility/use-cases?hl=ja#open-urls-custom-tabs
2. WebViewでハンドリングできてない問題を修正しました。

> [!note]
> なぜChromeとWebViewどちらもあるかというと、Chromeが利用できない動作環境の場合にWebViewにフォールバックするようにしているためです。Chromeが見つからない時だけ、WebViewを使うようにしていましたが、Chromeを見つけられrない問題と、WebViewが使えない問題が二重で発生していたというのが本PRの背景です。

> [!warning]
> レアケースですが、Chromeアプリが初期画面になっている場合、3Dセキュアの認証画面が立ち上がらない場合があります。これは認証画面のブラウザとして Chrome Custom Tabs を利用しているためで、バックキーなどでキャンセルした場合と判別がつかないためSDKでは対応していません。
> Chromeアプリ側の初期画面を完了しておくことで解決されます。


https://github.com/user-attachments/assets/ce29fd27-f29e-49e9-b7fe-8e7c30f42fe5


https://github.com/user-attachments/assets/37ec9893-ce9a-4c3b-b31e-01aec647b3b9

