### PR TITLE
トークン作成リクエスト時に3Dセキュア実施可否を設定する

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.5.1"
+agp = "8.6.1"
 ksp = "2.0.0-1.0.21"
 dokka = "1.9.20"
 spotless = "5.6.1"

--- a/payjp-android-cardform/src/main/kotlin/jp/pay/android/PayjpCardForm.kt
+++ b/payjp-android-cardform/src/main/kotlin/jp/pay/android/PayjpCardForm.kt
@@ -128,21 +128,25 @@ object PayjpCardForm {
      * @param tenant tenant (only for platformer)
      * @param face card form face. The default is [FACE_MULTI_LINE].
      * @param extraAttributes additional attributes for 3-D Secure. The default is [ExtraAttribute.defaults].
+     * @param useThreeDSecure whether use 3-D secure or not. The default is `false`.
      */
     @MainThread
     @JvmOverloads
+    @Suppress("LongParameterList")
     fun start(
         activity: Activity,
         requestCode: Int? = null,
         tenant: TenantId? = null,
         @CardFormFace face: Int = FACE_MULTI_LINE,
         extraAttributes: Array<ExtraAttribute<*>> = ExtraAttribute.defaults(),
+        useThreeDSecure: Boolean = false,
     ) = PayjpCardFormActivity.start(
         activity = activity,
         requestCode = requestCode,
         tenant = tenant,
         face = face,
         extraAttributes = extraAttributes,
+        useThreeDSecure = useThreeDSecure,
     )
 
     /**
@@ -152,21 +156,25 @@ object PayjpCardForm {
      * @param requestCode requestCode. The default is [PayjpCardFormActivity.DEFAULT_CARD_FORM_REQUEST_CODE]
      * @param tenant tenant (only for platformer)
      * @param extraAttributes additional attributes for 3-D Secure. The default is [ExtraAttribute.defaults].
+     * @param useThreeDSecure whether use 3-D secure or not. The default is `false`.
      */
     @MainThread
     @JvmOverloads
+    @Suppress("LongParameterList")
     fun start(
         fragment: Fragment,
         requestCode: Int? = null,
         tenant: TenantId? = null,
         @CardFormFace face: Int = FACE_MULTI_LINE,
         extraAttributes: Array<ExtraAttribute<*>> = ExtraAttribute.defaults(),
+        useThreeDSecure: Boolean = false,
     ) = PayjpCardFormActivity.start(
         fragment = fragment,
         requestCode = requestCode,
         tenant = tenant,
         face = face,
         extraAttributes = extraAttributes,
+        useThreeDSecure = useThreeDSecure,
     )
 
     /**

--- a/payjp-android-cardform/src/main/kotlin/jp/pay/android/ui/PayjpCardFormActivity.kt
+++ b/payjp-android-cardform/src/main/kotlin/jp/pay/android/ui/PayjpCardFormActivity.kt
@@ -68,6 +68,7 @@ internal class PayjpCardFormActivity :
         private const val EXTRA_KEY_TENANT = "EXTRA_KEY_TENANT"
         private const val EXTRA_KEY_FACE = "EXTRA_KEY_FACE"
         private const val EXTRA_KEY_EXTRA_ATTRIBUTES = "EXTRA_KEY_EXTRA_ATTRIBUTES"
+        private const val EXTRA_KEY_USE_THREE_D_SECURE = "EXTRA_KEY_USE_THREE_D_SECURE"
         private const val CARD_FORM_EXTRA_KEY_TOKEN = "DATA"
 
         fun createIntent(
@@ -75,9 +76,11 @@ internal class PayjpCardFormActivity :
             tenant: TenantId?,
             @PayjpCardForm.CardFormFace face: Int,
             extraAttributes: Array<ExtraAttribute<*>>,
+            useThreeDSecure: Boolean,
         ): Intent = Intent(context, PayjpCardFormActivity::class.java)
             .putExtra(EXTRA_KEY_FACE, face)
             .putExtra(EXTRA_KEY_EXTRA_ATTRIBUTES, extraAttributes)
+            .putExtra(EXTRA_KEY_USE_THREE_D_SECURE, useThreeDSecure)
             .apply {
                 if (tenant != null) {
                     putExtra(EXTRA_KEY_TENANT, tenant.id)
@@ -90,9 +93,10 @@ internal class PayjpCardFormActivity :
             tenant: TenantId?,
             @PayjpCardForm.CardFormFace face: Int,
             extraAttributes: Array<ExtraAttribute<*>>,
+            useThreeDSecure: Boolean,
         ) {
             activity.startActivityForResult(
-                createIntent(activity, tenant, face, extraAttributes)
+                createIntent(activity, tenant, face, extraAttributes, useThreeDSecure)
                     .addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP),
                 requestCode ?: DEFAULT_CARD_FORM_REQUEST_CODE
             )
@@ -104,9 +108,10 @@ internal class PayjpCardFormActivity :
             tenant: TenantId?,
             @PayjpCardForm.CardFormFace face: Int,
             extraAttributes: Array<ExtraAttribute<*>>,
+            useThreeDSecure: Boolean,
         ) {
             fragment.startActivityForResult(
-                createIntent(fragment.requireActivity(), tenant, face, extraAttributes)
+                createIntent(fragment.requireActivity(), tenant, face, extraAttributes, useThreeDSecure)
                     .addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP),
                 requestCode ?: DEFAULT_CARD_FORM_REQUEST_CODE
             )
@@ -140,6 +145,9 @@ internal class PayjpCardFormActivity :
             ?.filterIsInstance<ExtraAttribute<*>>()
             ?.toTypedArray()
             ?: emptyArray()
+    }
+    private val useThreeDSecure: Boolean by lazy {
+        intent?.getBooleanExtra(EXTRA_KEY_USE_THREE_D_SECURE, false) ?: false
     }
     private val inputMethodManager: InputMethodManager by lazy {
         getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
@@ -268,7 +276,7 @@ internal class PayjpCardFormActivity :
         inputMethodManager.hideSoftInputFromWindow(windowToken, InputMethodManager.HIDE_NOT_ALWAYS)
         cardFormFragment?.let { cardForm ->
             if (cardForm.isValid) {
-                viewModel?.onCreateToken(cardForm.createToken())
+                viewModel?.onCreateToken(cardForm.createToken(useThreeDSecure))
             }
         }
     }

--- a/payjp-android-cardform/src/main/kotlin/jp/pay/android/ui/widget/CardFormViewModel.kt
+++ b/payjp-android-cardform/src/main/kotlin/jp/pay/android/ui/widget/CardFormViewModel.kt
@@ -209,7 +209,7 @@ internal class CardFormViewModel(
         forceValidate(cardPhoneNumberInput, cardPhoneNumberInputTransformer)
     }
 
-    override fun createToken(): Task<Token> {
+    override fun createToken(useThreeDSecure: Boolean): Task<Token> {
         return if (isValid.value == true) {
             tokenService.createToken(
                 number = checkNotNull(cardNumberInput.value?.value),
@@ -220,6 +220,7 @@ internal class CardFormViewModel(
                 tenantId = tenantId,
                 email = cardEmailInput.value?.value,
                 phone = cardPhoneNumberInput.value?.value,
+                threeDSecure = useThreeDSecure,
             )
         } else {
             Tasks.failure(

--- a/payjp-android-cardform/src/main/kotlin/jp/pay/android/ui/widget/CardFormViewModelInput.kt
+++ b/payjp-android-cardform/src/main/kotlin/jp/pay/android/ui/widget/CardFormViewModelInput.kt
@@ -44,5 +44,5 @@ internal interface CardFormViewModelInput {
 
     fun validate()
 
-    fun createToken(): Task<Token>
+    fun createToken(useThreeDSecure: Boolean = false): Task<Token>
 }

--- a/payjp-android-cardform/src/main/kotlin/jp/pay/android/ui/widget/PayjpCardFormAbstractFragment.kt
+++ b/payjp-android-cardform/src/main/kotlin/jp/pay/android/ui/widget/PayjpCardFormAbstractFragment.kt
@@ -166,7 +166,11 @@ abstract class PayjpCardFormAbstractFragment :
     }
 
     override fun createToken(): Task<Token> {
-        return viewModel?.createToken() ?: Tasks.failure(
+        return createToken(useThreeDSecure = false)
+    }
+
+    override fun createToken(useThreeDSecure: Boolean): Task<Token> {
+        return viewModel?.createToken(useThreeDSecure) ?: Tasks.failure(
             PayjpInvalidCardFormException("Card form is not ready.")
         )
     }

--- a/payjp-android-cardform/src/main/kotlin/jp/pay/android/ui/widget/PayjpCardFormCardDisplayFragment.kt
+++ b/payjp-android-cardform/src/main/kotlin/jp/pay/android/ui/widget/PayjpCardFormCardDisplayFragment.kt
@@ -62,6 +62,7 @@ class PayjpCardFormCardDisplayFragment : PayjpCardFormAbstractFragment() {
          *
          * @param tenantId a option for platform tenant.
          * @param acceptedBrands accepted brands. if it is null, the fragment try to get them.
+         * @param extraAttributes extra attributes for 3-D secure.
          * @return fragment
          */
         @JvmStatic

--- a/payjp-android-cardform/src/main/kotlin/jp/pay/android/ui/widget/PayjpCardFormFragment.kt
+++ b/payjp-android-cardform/src/main/kotlin/jp/pay/android/ui/widget/PayjpCardFormFragment.kt
@@ -60,7 +60,7 @@ class PayjpCardFormFragment : PayjpCardFormAbstractFragment() {
          *
          * @param tenantId a option for platform tenant.
          * @param acceptedBrands accepted brands. if it is null, the fragment try to get them.
-         * @param extraAttributes a option for 3D secure attributes.
+         * @param extraAttributes a option for 3-D secure attributes.
          * @return fragment
          */
         @JvmStatic

--- a/payjp-android-cardform/src/main/kotlin/jp/pay/android/ui/widget/PayjpCardFormView.java
+++ b/payjp-android-cardform/src/main/kotlin/jp/pay/android/ui/widget/PayjpCardFormView.java
@@ -57,12 +57,21 @@ public interface PayjpCardFormView {
 
     /**
      * Create token.
-     *
      * @return task
      * @see [jp.pay.android.PayjpTokenService.createToken]
      */
     @NonNull
     Task<Token> createToken();
+
+    /**
+     * Create token with 3-D Secure.
+     *
+     * @param useThreeDSecure if true, use 3-D secure.
+     * @return task
+     * @see [jp.pay.android.PayjpTokenService.createToken]
+     */
+    @NonNull
+    Task<Token> createToken(boolean useThreeDSecure);
 
     /**
      * listener for every validation result.

--- a/payjp-android-cardform/src/test/kotlin/jp/pay/android/ui/pageobject/CardFormPage.kt
+++ b/payjp-android-cardform/src/test/kotlin/jp/pay/android/ui/pageobject/CardFormPage.kt
@@ -51,7 +51,8 @@ internal object CardFormPage {
                 extraAttributes = arrayOf(
                     ExtraAttribute.Email(),
                     ExtraAttribute.Phone("JP"),
-                )
+                ),
+                useThreeDSecure = true,
             )
         )
     }
@@ -65,7 +66,8 @@ internal object CardFormPage {
                 extraAttributes = arrayOf(
                     ExtraAttribute.Email(),
                     ExtraAttribute.Phone("JP"),
-                )
+                ),
+                useThreeDSecure = true,
             )
         )
     }

--- a/payjp-android-cardform/src/test/kotlin/jp/pay/android/ui/widget/CardFormViewModelTest.kt
+++ b/payjp-android-cardform/src/test/kotlin/jp/pay/android/ui/widget/CardFormViewModelTest.kt
@@ -638,7 +638,7 @@ internal class CardFormViewModelTest {
             inputEmail(robot.email)
             selectCountryCode(CountryCode(robot.countryRegion, robot.countryCode))
             inputPhoneNumber(robot.phoneNumber)
-            createToken().run()
+            createToken(useThreeDSecure = true).run()
             verify(mockTokenService).createToken(
                 number = "4242424242424242",
                 expMonth = "12",
@@ -648,13 +648,13 @@ internal class CardFormViewModelTest {
                 tenantId = null,
                 email = "test@example.com",
                 phone = "+819012345678",
-                threeDSecure = false,
+                threeDSecure = true,
             )
         }
     }
 
     @Test
-    fun validateCardForm_true_with_correct_input_and_token() {
+    fun validateCardForm_true_with_correct_input_and_tenantId() {
         `when`(
             mockTokenService.createToken(
                 number = anyString(),
@@ -685,7 +685,7 @@ internal class CardFormViewModelTest {
             inputEmail(robot.email)
             selectCountryCode(CountryCode(robot.countryRegion, robot.countryCode))
             inputPhoneNumber(robot.phoneNumber)
-            createToken().run()
+            createToken(useThreeDSecure = true).run()
             verify(mockTokenService).createToken(
                 number = "4242424242424242",
                 expMonth = "12",
@@ -695,7 +695,7 @@ internal class CardFormViewModelTest {
                 tenantId = tenantId,
                 email = "test@example.com",
                 phone = "+819012345678",
-                threeDSecure = false,
+                threeDSecure = true,
             )
         }
     }

--- a/payjp-android-cardform/src/test/kotlin/jp/pay/android/ui/widget/CardFormViewModelTest.kt
+++ b/payjp-android-cardform/src/test/kotlin/jp/pay/android/ui/widget/CardFormViewModelTest.kt
@@ -55,6 +55,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.Mockito.`when`
+import org.mockito.Mockito.anyBoolean
 import org.mockito.Mockito.anyString
 import org.mockito.Mockito.never
 import org.mockito.Mockito.reset
@@ -618,6 +619,7 @@ internal class CardFormViewModelTest {
                 tenantId = anyNullable(),
                 email = anyString(),
                 phone = anyString(),
+                threeDSecure = anyBoolean(),
             )
         )
             .thenReturn(Tasks.success(TestStubs.newToken()))
@@ -646,6 +648,7 @@ internal class CardFormViewModelTest {
                 tenantId = null,
                 email = "test@example.com",
                 phone = "+819012345678",
+                threeDSecure = false,
             )
         }
     }
@@ -662,6 +665,7 @@ internal class CardFormViewModelTest {
                 tenantId = anyNullable(),
                 email = anyString(),
                 phone = anyString(),
+                threeDSecure = anyBoolean(),
             )
         )
             .thenReturn(Tasks.success(TestStubs.newToken()))
@@ -691,6 +695,7 @@ internal class CardFormViewModelTest {
                 tenantId = tenantId,
                 email = "test@example.com",
                 phone = "+819012345678",
+                threeDSecure = false,
             )
         }
     }

--- a/payjp-android-core/src/main/kotlin/jp/pay/android/PayjpApi.kt
+++ b/payjp-android-core/src/main/kotlin/jp/pay/android/PayjpApi.kt
@@ -38,6 +38,7 @@ import retrofit2.http.Query
  *
  * see https://pay.jp/docs/api/#introduction
  */
+@Suppress("LongParameterList")
 internal interface PayjpApi {
 
     @POST("tokens")
@@ -52,6 +53,7 @@ internal interface PayjpApi {
         @Field("tenant") tenant: String?,
         @Field("card[email]") email: String?,
         @Field("card[phone]") phone: String?,
+        @Field("three_d_secure") threeDSecure: Boolean,
     ): ResultCall<Token>
 
     @POST("tokens/{id}/tds_finish")

--- a/payjp-android-core/src/main/kotlin/jp/pay/android/PayjpToken.kt
+++ b/payjp-android-core/src/main/kotlin/jp/pay/android/PayjpToken.kt
@@ -96,6 +96,7 @@ class PayjpToken internal constructor(
             tenant = param.tenantId?.id,
             email = param.email,
             phone = param.phone,
+            threeDSecure = param.threeDSecure
         ).let { this.wrapWithObserver(it) }
     }
 

--- a/payjp-android-core/src/main/kotlin/jp/pay/android/PayjpTokenParam.kt
+++ b/payjp-android-core/src/main/kotlin/jp/pay/android/PayjpTokenParam.kt
@@ -35,6 +35,7 @@ import jp.pay.android.model.TenantId
  * @param tenantId optional tenant id (only for platform)
  * @param email email
  * @param phone phone number formatted by E.164 (e.g. +819012345678)
+ * @param threeDSecure whether use 3-D secure or not
  */
 data class PayjpTokenParam(
     val number: String,
@@ -45,6 +46,7 @@ data class PayjpTokenParam(
     val tenantId: TenantId?,
     val email: String?,
     val phone: String?,
+    val threeDSecure: Boolean,
 ) {
 
     /**
@@ -66,6 +68,7 @@ data class PayjpTokenParam(
         private var tenantId: TenantId? = null
         private var email: String? = null
         private var phone: String? = null
+        private var threeDSecure: Boolean = false
 
         /**
          * Set card holder name
@@ -97,11 +100,18 @@ data class PayjpTokenParam(
         fun phone(phone: String?): Builder = apply { this.phone = phone }
 
         /**
+         * Set 3-D secure
+         *
+         * @param threeDSecure whether use 3-D secure or not
+         */
+        fun threeDSecure(threeDSecure: Boolean): Builder = apply { this.threeDSecure = threeDSecure }
+
+        /**
          * Build param
          *
          * @return param object.
          */
         fun build(): PayjpTokenParam =
-            PayjpTokenParam(number, cvc, expMonth, expYear, name, tenantId, email, phone)
+            PayjpTokenParam(number, cvc, expMonth, expYear, name, tenantId, email, phone, threeDSecure)
     }
 }

--- a/payjp-android-core/src/main/kotlin/jp/pay/android/PayjpTokenService.kt
+++ b/payjp-android-core/src/main/kotlin/jp/pay/android/PayjpTokenService.kt
@@ -45,8 +45,10 @@ interface PayjpTokenService {
      * @param tenantId tenant id (only for platform)
      * @param email email
      * @param phone phone
+     * @param threeDSecure whether use 3-D secure or not
      * @return task to create token.
      */
+    @Suppress("LongParameterList")
     fun createToken(
         number: String,
         cvc: String,
@@ -56,8 +58,9 @@ interface PayjpTokenService {
         tenantId: TenantId? = null,
         email: String? = null,
         phone: String? = null,
+        threeDSecure: Boolean = false,
     ): Task<Token> = createToken(
-        PayjpTokenParam(number, cvc, expMonth, expYear, name, tenantId, email, phone)
+        PayjpTokenParam(number, cvc, expMonth, expYear, name, tenantId, email, phone, threeDSecure)
     )
 
     /**

--- a/payjp-android-core/src/test/kotlin/jp/pay/android/PayjpTokenTest.kt
+++ b/payjp-android-core/src/test/kotlin/jp/pay/android/PayjpTokenTest.kt
@@ -145,11 +145,14 @@ class PayjpTokenTest {
                 )
                 assertEquals("en", request.getHeader("Locale"))
                 assertEquals(
-                    "card%5Bnumber%5D=4242424242424242" +
-                        "&card%5Bcvc%5D=123" +
-                        "&card%5Bexp_month%5D=02" +
-                        "&card%5Bexp_year%5D=2020" +
-                        "&card%5Bname%5D=TARO%20YAMADA",
+                    """
+                        card%5Bnumber%5D=4242424242424242
+                        &card%5Bcvc%5D=123
+                        &card%5Bexp_month%5D=02
+                        &card%5Bexp_year%5D=2020
+                        &card%5Bname%5D=TARO%20YAMADA
+                        &three_d_secure=false
+                    """.trimIndent().replace("\n", ""),
                     request.body.readString(Charset.forName("utf-8"))
                 )
             }
@@ -169,10 +172,13 @@ class PayjpTokenTest {
             .run()
 
         assertEquals(
-            "card%5Bnumber%5D=4242424242424242" +
-                "&card%5Bcvc%5D=123" +
-                "&card%5Bexp_month%5D=02" +
-                "&card%5Bexp_year%5D=2020",
+            """
+                card%5Bnumber%5D=4242424242424242
+                &card%5Bcvc%5D=123
+                &card%5Bexp_month%5D=02
+                &card%5Bexp_year%5D=2020
+                &three_d_secure=false
+            """.trimIndent().replace("\n", ""),
             mockWebServer.takeRequest().body.readString(Charset.forName("utf-8"))
         )
     }
@@ -192,11 +198,14 @@ class PayjpTokenTest {
             .run()
 
         assertEquals(
-            "card%5Bnumber%5D=4242424242424242" +
-                "&card%5Bcvc%5D=123" +
-                "&card%5Bexp_month%5D=02" +
-                "&card%5Bexp_year%5D=2020" +
-                "&tenant=tenant_id",
+            """
+                card%5Bnumber%5D=4242424242424242
+                &card%5Bcvc%5D=123
+                &card%5Bexp_month%5D=02
+                &card%5Bexp_year%5D=2020
+                &tenant=tenant_id
+                &three_d_secure=false
+            """.trimIndent().replace("\n", ""),
             mockWebServer.takeRequest().body.readString(Charset.forName("utf-8"))
         )
     }
@@ -217,12 +226,43 @@ class PayjpTokenTest {
             .run()
 
         assertEquals(
-            "card%5Bnumber%5D=4242424242424242" +
-                "&card%5Bcvc%5D=123" +
-                "&card%5Bexp_month%5D=02" +
-                "&card%5Bexp_year%5D=2020" +
-                "&card%5Bemail%5D=test%40example.com" +
-                "&card%5Bphone%5D=%2B819012345678",
+            """
+                card%5Bnumber%5D=4242424242424242
+                &card%5Bcvc%5D=123
+                &card%5Bexp_month%5D=02
+                &card%5Bexp_year%5D=2020
+                &card%5Bemail%5D=test%40example.com
+                &card%5Bphone%5D=%2B819012345678
+                &three_d_secure=false
+            """.trimIndent().replace("\n", ""),
+            mockWebServer.takeRequest().body.readString(Charset.forName("utf-8"))
+        )
+    }
+
+    @Test
+    fun createToken_with_three_d_secure() {
+        mockWebServer.enqueue(MockResponse().setResponseCode(200).setBody(TOKEN_OK))
+
+        createTokenService()
+            .createToken(
+                number = "4242424242424242",
+                cvc = "123",
+                expMonth = "02",
+                expYear = "2020",
+                name = "TARO YAMADA",
+                threeDSecure = true,
+            )
+            .run()
+
+        assertEquals(
+            """
+                card%5Bnumber%5D=4242424242424242
+                &card%5Bcvc%5D=123
+                &card%5Bexp_month%5D=02
+                &card%5Bexp_year%5D=2020
+                &card%5Bname%5D=TARO%20YAMADA
+                &three_d_secure=true
+            """.trimIndent().replace("\n", ""),
             mockWebServer.takeRequest().body.readString(Charset.forName("utf-8"))
         )
     }
@@ -295,7 +335,7 @@ class PayjpTokenTest {
         try {
             task.run()
             fail()
-        } catch (e: IOException) {
+        } catch (_: IOException) {
         }
     }
 
@@ -424,7 +464,7 @@ class PayjpTokenTest {
         try {
             task.run()
             fail()
-        } catch (e: IOException) {
+        } catch (_: IOException) {
         }
     }
 

--- a/payjp-android-coroutine/src/main/kotlin/jp/pay/android/coroutine/PayjpCoroutineExt.kt
+++ b/payjp-android-coroutine/src/main/kotlin/jp/pay/android/coroutine/PayjpCoroutineExt.kt
@@ -39,10 +39,12 @@ import kotlin.coroutines.suspendCoroutine
 /**
  * Create token by suspend function.
  *
+ * @param useThreeDSecure if true, use 3-D secure.
  * @return token
  * @see [PayjpCardFormView.createToken]
  */
-suspend fun PayjpCardFormView.createTokenSuspend(): Token = createToken().toSuspend()
+suspend fun PayjpCardFormView.createTokenSuspend(useThreeDSecure: Boolean = false): Token =
+    createToken(useThreeDSecure).toSuspend()
 
 /**
  * Create token with param by suspend function.

--- a/payjp-android-coroutine/src/test/kotlin/jp/pay/android/coroutine/PayjpCoroutineExtTest.kt
+++ b/payjp-android-coroutine/src/test/kotlin/jp/pay/android/coroutine/PayjpCoroutineExtTest.kt
@@ -70,10 +70,10 @@ class PayjpCoroutineExtTest {
     @Test
     fun createTokenSuspend_failure() {
         val error = RuntimeException("omg")
-        `when`(payjpCardFormView.createToken()).thenReturn(Tasks.failure(error))
+        `when`(payjpCardFormView.createToken(false)).thenReturn(Tasks.failure(error))
         runBlocking {
             try {
-                payjpCardFormView.createTokenSuspend()
+                payjpCardFormView.createTokenSuspend(false)
                 fail("unexpected statement")
             } catch (e: Throwable) {
                 assertThat(e.message, `is`(error.message))
@@ -84,9 +84,18 @@ class PayjpCoroutineExtTest {
     @Test
     fun createTokenSuspend_success() {
         val token = TestStubs.newToken(seed = 1)
-        `when`(payjpCardFormView.createToken()).thenReturn(Tasks.success(token))
+        `when`(payjpCardFormView.createToken(false)).thenReturn(Tasks.success(token))
         runBlocking {
             assertThat(payjpCardFormView.createTokenSuspend().id, `is`(token.id))
+        }
+    }
+
+    @Test
+    fun createTokenSuspend_useThreeDSecure_success() {
+        val token = TestStubs.newToken(seed = 1)
+        `when`(payjpCardFormView.createToken(true)).thenReturn(Tasks.success(token))
+        runBlocking {
+            assertThat(payjpCardFormView.createTokenSuspend(useThreeDSecure = true).id, `is`(token.id))
         }
     }
 

--- a/payjp-android-coroutine/src/test/kotlin/jp/pay/android/coroutine/PayjpCoroutineExtTest.kt
+++ b/payjp-android-coroutine/src/test/kotlin/jp/pay/android/coroutine/PayjpCoroutineExtTest.kt
@@ -59,6 +59,7 @@ class PayjpCoroutineExtTest {
         tenantId = null,
         email = null,
         phone = null,
+        threeDSecure = false,
     )
 
     @Before

--- a/sample/src/main/kotlin/com/example/payjp/sample/CardFormViewSampleActivity.kt
+++ b/sample/src/main/kotlin/com/example/payjp/sample/CardFormViewSampleActivity.kt
@@ -131,7 +131,7 @@ class CardFormViewSampleActivity :
 
     private fun createToken() {
         // create token
-        createToken = cardFormFragment.createToken()
+        createToken = cardFormFragment.createToken(useThreeDSecure = true)
         tokenizeProcessing = true
         updateButtonVisibility()
         binding.textTokenContent.text = "running..."
@@ -202,12 +202,12 @@ class CardFormViewSampleActivity :
     }
 
     private fun showThemeChooserDialog() {
-        val items = Theme.values().map { it.name }
-        val current = Theme.values().toList().indexOf(restoreTheme())
+        val items = Theme.entries.map { it.name }
+        val current = Theme.entries.indexOf(restoreTheme())
         AlertDialog.Builder(this)
             .setTitle("テーマを選択")
             .setSingleChoiceItems(items.toTypedArray(), current) { _, which ->
-                val theme = Theme.values()[which]
+                val theme = Theme.entries[which]
                 changeTheme(theme)
             }
             .create()
@@ -262,7 +262,8 @@ class CardFormViewSampleActivity :
     }
 
     private fun updateButtonVisibility() {
-        if (!tokenizeProcessing && Payjp.token().getTokenOperationObserver().status == PayjpTokenOperationStatus.ACCEPTABLE) {
+        if (!tokenizeProcessing &&
+            Payjp.token().getTokenOperationObserver().status == PayjpTokenOperationStatus.ACCEPTABLE) {
             binding.layoutButtons.visibility = View.VISIBLE
             binding.progressBar.visibility = View.GONE
         } else {

--- a/sample/src/main/kotlin/com/example/payjp/sample/CardFormViewSampleActivity.kt
+++ b/sample/src/main/kotlin/com/example/payjp/sample/CardFormViewSampleActivity.kt
@@ -263,7 +263,8 @@ class CardFormViewSampleActivity :
 
     private fun updateButtonVisibility() {
         if (!tokenizeProcessing &&
-            Payjp.token().getTokenOperationObserver().status == PayjpTokenOperationStatus.ACCEPTABLE) {
+            Payjp.token().getTokenOperationObserver().status == PayjpTokenOperationStatus.ACCEPTABLE
+        ) {
             binding.layoutButtons.visibility = View.VISIBLE
             binding.progressBar.visibility = View.GONE
         } else {

--- a/sample/src/main/kotlin/com/example/payjp/sample/CoroutineSampleActivity.kt
+++ b/sample/src/main/kotlin/com/example/payjp/sample/CoroutineSampleActivity.kt
@@ -94,7 +94,7 @@ class CoroutineSampleActivity : AppCompatActivity(), CoroutineScope by MainScope
         try {
             val token = withContext(Dispatchers.IO) {
                 if (tokenId == null) {
-                    cardFormFragment.createTokenSuspend()
+                    cardFormFragment.createTokenSuspend(useThreeDSecure = true)
                 } else {
                     Payjp.token().finishTokenTdsSuspend(tokenId = tokenId)
                 }

--- a/sample/src/main/kotlin/com/example/payjp/sample/TopActivity.kt
+++ b/sample/src/main/kotlin/com/example/payjp/sample/TopActivity.kt
@@ -123,7 +123,8 @@ class TopActivity : AppCompatActivity() {
                 Payjp.cardForm().start(
                     activity = this,
                     face = face,
-                    extraAttributes = attributes
+                    extraAttributes = attributes,
+                    useThreeDSecure = true,
                 )
             }
             .setNegativeButton("Cancel", null)


### PR DESCRIPTION
POST /v1/tokens をリクエストする際に three_d_secure パラメータを追加します。

## PayjpCardForm

`PayjpCardForm.start` に `useThreeDSecure` が追加されます。デフォルトは false です。

```diff
 Payjp.cardForm().start(
     activity = this,
     face = PayjpCardForm.FACE_MULTI_LINE,
     extraAttributes = arrayOf(ExtraAttribute.Email()),
+    useThreeDSecure = true,
 )
```

## PayjpCardFormView

`PayjpCardFormView.createToken` に `useThreeDSecure` が追加されます。デフォルトは false です。

```diff
- cardFormFragment.createToken()
+ cardFormFragment.createToken(useThreeDSecure = true)
```