### PR TITLE
「支払い時」「顧客カードに対する3Dセキュア」に対応

### DIFF
--- a/payjp-android-cardform/src/main/kotlin/jp/pay/android/ui/CardFormScreenViewModel.kt
+++ b/payjp-android-cardform/src/main/kotlin/jp/pay/android/ui/CardFormScreenViewModel.kt
@@ -136,7 +136,7 @@ internal class CardFormScreenViewModel(
         if (result.isSuccess()) {
             tokenizeProcessing.value = true
             when (result) {
-                is PayjpThreeDSecureResult.SuccessTokenId -> finishTokenTds(result.id)
+                is PayjpThreeDSecureResult.SuccessResourceId -> finishTokenTds(result.retrieveTokenId())
                 else -> throw IllegalStateException("illegal result: $result")
             }
         } else {

--- a/payjp-android-cardform/src/main/kotlin/jp/pay/android/ui/PayjpCardFormActivity.kt
+++ b/payjp-android-cardform/src/main/kotlin/jp/pay/android/ui/PayjpCardFormActivity.kt
@@ -306,7 +306,7 @@ internal class PayjpCardFormActivity :
     }
 
     private fun startVerify(tokenId: TokenId) {
-        PayjpVerifier.startThreeDSecureFlow(tokenId, this)
+        PayjpVerifier.startThreeDSecureFlow(tokenId.id, this)
         viewModel?.onStartedVerify()
     }
 }

--- a/payjp-android-cardform/src/test/kotlin/jp/pay/android/ui/CardFormScreenViewModelTest.kt
+++ b/payjp-android-cardform/src/test/kotlin/jp/pay/android/ui/CardFormScreenViewModelTest.kt
@@ -96,6 +96,7 @@ class CardFormScreenViewModelTest {
         errorViewText.observeForever { }
         success.observeForever { }
         snackBarMessage.observeForever { }
+        startVerifyCommand.observeForever { }
     }
 
     @Test
@@ -440,7 +441,7 @@ class CardFormScreenViewModelTest {
         val viewModel = createViewModel(tokenHandlerExecutor = handlerExecutor)
 
         viewModel.onCreateToken(Tasks.success(tokenUnverified))
-        viewModel.onCompleteCardVerify(PayjpThreeDSecureResult.SuccessTokenId(tokenId))
+        viewModel.onCompleteCardVerify(PayjpThreeDSecureResult.SuccessResourceId(tokenId.id))
         FakeTokenOperationObserver.status = PayjpTokenOperationStatus.THROTTLED
 
         viewModel.run {
@@ -471,7 +472,7 @@ class CardFormScreenViewModelTest {
         val viewModel = createViewModel(tokenHandlerExecutor = mockTokenHandlerExecutor)
 
         viewModel.onCreateToken(Tasks.success(tokenUnverified))
-        viewModel.onCompleteCardVerify(PayjpThreeDSecureResult.SuccessTokenId(tokenId))
+        viewModel.onCompleteCardVerify(PayjpThreeDSecureResult.SuccessResourceId(tokenId.id))
         FakeTokenOperationObserver.status = PayjpTokenOperationStatus.THROTTLED
 
         viewModel.run {

--- a/payjp-android-core/build.gradle
+++ b/payjp-android-core/build.gradle
@@ -50,6 +50,7 @@ dependencies {
     implementation libs.okHttp3.core
     implementation libs.okHttp3.loggingInterceptor
     implementation libs.moshi.core
+    
     ksp libs.moshi.codegen
     implementation libs.retrofit.core
     implementation libs.retrofit.moshi
@@ -57,6 +58,7 @@ dependencies {
 
     testImplementation libs.okHttp3.mockServer
     testImplementation project(":common-test")
+    testImplementation project(':payjp-android-verifier')
 }
 
 mavenPublishing {

--- a/payjp-android-core/src/main/kotlin/jp/pay/android/PayjpConstants.kt
+++ b/payjp-android-core/src/main/kotlin/jp/pay/android/PayjpConstants.kt
@@ -22,7 +22,7 @@
  */
 package jp.pay.android
 
-internal object PayjpConstants {
+object PayjpConstants {
     const val API_HOST = "api.pay.jp"
     const val API_ENDPOINT = "https://$API_HOST/v1/"
 }

--- a/payjp-android-core/src/test/kotlin/jp/pay/android/model/TokenIdTest.kt
+++ b/payjp-android-core/src/test/kotlin/jp/pay/android/model/TokenIdTest.kt
@@ -24,6 +24,8 @@ package jp.pay.android.model
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import jp.pay.android.PayjpConstants
+import jp.pay.android.verifier.threeDSecure.getVerificationEntryUri
+import jp.pay.android.verifier.threeDSecure.getVerificationFinishUri
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.`is`
 import org.junit.Test
@@ -34,8 +36,8 @@ class TokenIdTest {
     @Test
     fun getTdsEntryUri() {
         val id = "tds_xxx"
-        val tokenId = TokenId(id = id)
-        val uri = tokenId.getVerificationEntryUri(
+        val uri = getVerificationEntryUri(
+            resourceId = id,
             publicKey = "pk_zzzz"
         )
         assertThat(
@@ -47,8 +49,8 @@ class TokenIdTest {
     @Test
     fun getTdsEntryUri_withRedirect() {
         val id = "tds_xxx"
-        val tokenId = TokenId(id = id)
-        val uri = tokenId.getVerificationEntryUri(
+        val uri = getVerificationEntryUri(
+            resourceId = id,
             publicKey = "pk_zzzz",
             redirectUrlName = "app"
         )
@@ -61,9 +63,8 @@ class TokenIdTest {
     @Test
     fun getTdsFinishUri() {
         val id = "tds_xxx"
-        val tokenId = TokenId(id = id)
         assertThat(
-            tokenId.getVerificationFinishUri().toString(),
+            getVerificationFinishUri(resourceId = id).toString(),
             `is`("${PayjpConstants.API_ENDPOINT}tds/$id/finish")
         )
     }

--- a/payjp-android-verifier/src/main/kotlin/jp/pay/android/verifier/threeDSecure/ThreeDSecureURLConfiguration.kt
+++ b/payjp-android-verifier/src/main/kotlin/jp/pay/android/verifier/threeDSecure/ThreeDSecureURLConfiguration.kt
@@ -20,10 +20,37 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package jp.pay.android.model
+package jp.pay.android.verifier.threeDSecure
 
-import android.os.Parcelable
-import kotlinx.parcelize.Parcelize
+import android.net.Uri
+import jp.pay.android.PayjpConstants
 
-@Parcelize
-data class TokenId(val id: String) : Parcelable
+/**
+ * Returns the entry URI for 3D Secure verification.
+ * Constructs a URL in the form: https://{API_HOST}/tds/{resourceId}/start
+ */
+fun getVerificationEntryUri(
+    resourceId: String,
+    publicKey: String,
+    redirectUrlName: String? = null
+): Uri {
+    val baseUrl = Uri.parse("${PayjpConstants.API_ENDPOINT}tds/$resourceId")
+    return baseUrl.buildUpon()
+        .appendPath("start")
+        .appendQueryParameter("publickey", publicKey)
+        .apply {
+            if (redirectUrlName != null) {
+                appendQueryParameter("back", redirectUrlName)
+            }
+        }
+        .build()
+}
+
+/**
+ * Returns the finish URI for 3D Secure verification.
+ * Constructs a URL in the form: https://{API_HOST}/tds/{resourceId}/finish
+ */
+fun getVerificationFinishUri(resourceId: String): Uri {
+    val baseUrl = Uri.parse("${PayjpConstants.API_ENDPOINT}tds/$resourceId")
+    return Uri.withAppendedPath(baseUrl, "finish")
+}

--- a/payjp-android-verifier/src/main/kotlin/jp/pay/android/verifier/ui/PayjpThreeDSecureResult.kt
+++ b/payjp-android-verifier/src/main/kotlin/jp/pay/android/verifier/ui/PayjpThreeDSecureResult.kt
@@ -32,9 +32,9 @@ sealed class PayjpThreeDSecureResult {
     /**
      * Success
      *
-     * @param id token id
+     * @param id resource id
      */
-    data class SuccessTokenId(val id: TokenId) : PayjpThreeDSecureResult()
+    data class SuccessResourceId(val id: String) : PayjpThreeDSecureResult()
 
     /**
      * Canceled
@@ -44,7 +44,7 @@ sealed class PayjpThreeDSecureResult {
     /**
      * Return it is success.
      */
-    fun isSuccess(): Boolean = this is SuccessTokenId
+    fun isSuccess(): Boolean = this is SuccessResourceId
 
     /**
      * Return it is canceled.
@@ -56,8 +56,8 @@ sealed class PayjpThreeDSecureResult {
      *
      */
     fun retrieveTokenId(): TokenId {
-        val success = this as? SuccessTokenId
+        val success = this as? SuccessResourceId
             ?: throw IllegalStateException("Cannot call retrieveToken() when it is not success")
-        return success.id
+        return TokenId(success.id)
     }
 }

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -54,6 +54,8 @@
             android:exported="false" />
         <activity android:name="com.example.payjp.sample.CoroutineSampleActivity"
             android:exported="false" />
+        <activity android:name="com.example.payjp.sample.ThreeDSecureExampleActivity"
+            android:exported="false" />
 
         <activity android:name="jp.pay.android.verifier.ui.PayjpThreeDSecureStepActivity"
                 android:enabled="true"

--- a/sample/src/main/kotlin/com/example/payjp/sample/ThreeDSecureExampleActivity.kt
+++ b/sample/src/main/kotlin/com/example/payjp/sample/ThreeDSecureExampleActivity.kt
@@ -1,0 +1,87 @@
+/*
+ *
+ * Copyright (c) 2021 PAY, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.example.payjp.sample
+
+import android.content.Intent
+import android.graphics.Color
+import android.os.Bundle
+import android.view.View
+import android.widget.Button
+import android.widget.EditText
+import android.widget.TextView
+import android.widget.Toast
+import androidx.appcompat.app.AppCompatActivity
+import androidx.core.graphics.toColorInt
+import jp.pay.android.verifier.PayjpVerifier
+
+class ThreeDSecureExampleActivity : AppCompatActivity() {
+
+    private lateinit var completeMessageView: TextView
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_three_d_secure_example)
+
+        val resourceIdInput = findViewById<EditText>(R.id.resource_id_input)
+        val start3DSecureButton = findViewById<Button>(R.id.start_3d_secure_button)
+        completeMessageView = findViewById(R.id.complete_message)
+
+        // Initially hide the message view
+        completeMessageView.visibility = View.GONE
+
+        start3DSecureButton.setOnClickListener {
+            val resourceId = resourceIdInput.text.toString()
+            if (resourceId.isNotEmpty()) {
+                completeMessageView.text = ""
+                completeMessageView.setTextColor(Color.BLACK)
+                completeMessageView.setBackgroundColor("#E8F5E9".toColorInt())
+                completeMessageView.visibility = View.GONE
+                PayjpVerifier.startThreeDSecureFlow(resourceId, this)
+            } else {
+                Toast.makeText(this, "Please enter a resource ID", Toast.LENGTH_SHORT).show()
+            }
+        }
+    }
+
+    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+        super.onActivityResult(requestCode, resultCode, data)
+        PayjpVerifier.handleThreeDSecureResult(requestCode) { result ->
+            when {
+                result.isSuccess() -> {
+                    completeMessageView.text = "3Dセキュア認証が終了しました。\nこの結果をサーバーサイドに伝え、完了処理や結果のハンドリングを行なってください。\n後続処理の実装方法に関してはドキュメントをご参照ください。"
+                    completeMessageView.visibility = View.VISIBLE
+                }
+                result.isCanceled() -> {
+                    completeMessageView.text = "3Dセキュア認証がキャンセルされました"
+                    completeMessageView.visibility = View.VISIBLE
+                }
+                else -> {
+                    completeMessageView.text = "3Dセキュア認証が失敗しました"
+                    completeMessageView.setBackgroundColor(Color.RED)
+                    completeMessageView.setTextColor(Color.WHITE)
+                    completeMessageView.visibility = View.VISIBLE
+                }
+            }
+        }
+    }
+}

--- a/sample/src/main/kotlin/com/example/payjp/sample/TopActivity.kt
+++ b/sample/src/main/kotlin/com/example/payjp/sample/TopActivity.kt
@@ -62,6 +62,11 @@ class TopActivity : AppCompatActivity() {
             Sample(
                 "CardFormView (Coroutine)",
                 Intent(this, CoroutineSampleActivity::class.java)
+            ),
+            Sample(
+                "ThreeDSecureExampleActivity",
+                Intent(this, ThreeDSecureExampleActivity::class.java),
+                headerText = "支払い時の3Dセキュア、または顧客カードの3Dセキュア"
             )
         )
     }
@@ -164,6 +169,13 @@ class TopActivity : AppCompatActivity() {
             set(value) {
                 field = value
                 binding.name.text = value?.name
+
+                if (value?.headerText != null) {
+                    binding.header.text = value.headerText
+                    binding.header.visibility = android.view.View.VISIBLE
+                } else {
+                    binding.header.visibility = android.view.View.GONE
+                }
             }
 
         init {
@@ -177,7 +189,12 @@ class TopActivity : AppCompatActivity() {
         }
     }
 
-    data class Sample(val name: String, val intent: Intent?, val startable: (() -> Unit)? = null) {
+    data class Sample(
+        val name: String,
+        val intent: Intent?,
+        val startable: (() -> Unit)? = null,
+        val headerText: String? = null
+    ) {
         fun start(activity: AppCompatActivity) {
             startable?.invoke() ?: intent?.let { activity.startActivity(it) }
         }

--- a/sample/src/main/res/layout/activity_three_d_secure_example.xml
+++ b/sample/src/main/res/layout/activity_three_d_secure_example.xml
@@ -1,0 +1,174 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:padding="16dp">
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="3Dセキュア"
+            android:textSize="24sp"
+            android:textStyle="bold"
+            android:layout_marginBottom="16dp" />
+
+        <androidx.cardview.widget.CardView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="16dp"
+            app:cardCornerRadius="8dp"
+            app:cardElevation="4dp">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                android:padding="16dp">
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="リソースID"
+                    android:textStyle="bold"
+                    android:layout_marginBottom="8dp" />
+
+                <com.google.android.material.textfield.TextInputLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:hint="リソースIDを入力">
+
+                    <com.google.android.material.textfield.TextInputEditText
+                        android:id="@+id/resource_id_input"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:inputType="text"
+                        android:text="tdsr_ce3c1d805452c981775e321288a" />
+                </com.google.android.material.textfield.TextInputLayout>
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/start_3d_secure_button"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="16dp"
+                    android:text="3Dセキュア認証を開始"
+                    app:icon="@android:drawable/ic_lock_lock" />
+            </LinearLayout>
+        </androidx.cardview.widget.CardView>
+
+        <TextView
+                    android:id="@+id/complete_message"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text=""
+                    android:textSize="14sp"
+                    android:background="#E8F5E9"
+                    android:visibility="gone"
+                    android:padding="8dp" />
+
+        <androidx.cardview.widget.CardView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:cardCornerRadius="8dp"
+            app:cardElevation="2dp">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                android:padding="16dp">
+
+                <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="手順"
+                    android:textStyle="bold"
+                    android:textSize="18sp"
+                    android:layout_marginBottom="16dp" />
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal"
+                    android:layout_marginBottom="12dp">
+
+                    <TextView
+                        android:layout_width="36dp"
+                        android:layout_height="36dp"
+                        android:text="1"
+                        android:textSize="18sp"
+                        android:textStyle="bold"
+                        android:gravity="center"
+                        android:textColor="#FFFFFF"
+                        android:background="@android:color/holo_blue_dark"
+                        android:layout_marginEnd="12dp"
+                        android:layout_marginRight="12dp" />
+
+                    <TextView
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:minHeight="200dp"
+                        android:autoLink="web"
+                        android:text="下記を参考に、先にサーバーサイドで支払い、または3Dセキュアリクエストを作成してください。\n\n支払い作成時の3Dセキュア：\nhttps://pay.jp/docs/charge-tds\n顧客カードに対する3Dセキュア：\nhttps://pay.jp/docs/customer-card-tds"
+                        android:textSize="14sp" />
+                </LinearLayout>
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal"
+                    android:layout_marginBottom="12dp">
+
+                    <TextView
+                        android:layout_width="36dp"
+                        android:layout_height="36dp"
+                        android:text="2"
+                        android:textSize="18sp"
+                        android:textStyle="bold"
+                        android:gravity="center"
+                        android:textColor="#FFFFFF"
+                        android:background="@android:color/holo_blue_dark"
+                        android:layout_marginEnd="12dp"
+                        android:layout_marginRight="12dp" />
+
+                    <TextView
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:minHeight="100dp"
+                        android:text="作成したリソースのIDを上記に入力して3Dセキュアを開始してください。"
+                        android:textSize="14sp" />
+                </LinearLayout>
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal">
+
+                    <TextView
+                        android:layout_width="36dp"
+                        android:layout_height="36dp"
+                        android:text="3"
+                        android:textSize="18sp"
+                        android:textStyle="bold"
+                        android:gravity="center"
+                        android:textColor="#FFFFFF"
+                        android:background="@android:color/holo_blue_dark"
+                        android:layout_marginEnd="12dp"
+                        android:layout_marginRight="12dp" />
+
+                    <TextView
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:minHeight="100dp"
+                        android:text="立ち上がった画面が閉じ、認証が終了したら、ドキュメントを参考にサーバーサイドにて結果を確認してください。"
+                        android:textSize="14sp" />
+                </LinearLayout>
+            </LinearLayout>
+        </androidx.cardview.widget.CardView>
+    </LinearLayout>
+</ScrollView>

--- a/sample/src/main/res/layout/card_sample.xml
+++ b/sample/src/main/res/layout/card_sample.xml
@@ -39,14 +39,31 @@
             app:cardElevation="4dp"
             android:background="?android:selectableItemBackground">
 
-        <TextView
-                android:id="@+id/name"
+        <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                android:padding="16dp">
+
+            <TextView
+                android:id="@+id/header"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:padding="16dp"
-                style="@style/TextAppearance.AppCompat.Title"
-                tools:text="Sample"/>
+                android:textColor="@android:color/darker_gray"
+                android:textSize="14sp"
+                android:visibility="gone"
+                tools:text="Header"
+                tools:visibility="visible" />
 
+            <TextView
+                    android:id="@+id/name"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="4dp"
+                    style="@style/TextAppearance.AppCompat.Title"
+                    tools:text="Sample"/>
+
+        </LinearLayout>
 
     </androidx.cardview.widget.CardView>
 


### PR DESCRIPTION
## 3Dセキュア認証フロー
- `PayjpVerifier`クラスの`startThreeDSecureFlow`メソッドを更新し、リソースID（トークンID、支払いID、顧客カードIDなど）を直接受け取るように変更しました。
- `TokenId`クラスから3Dセキュア認証のURI生成に関するロジックを削除し、`payjp-android-verifier/src/main/kotlin/jp/pay/android/verifier/threeDSecure/ThreeDSecureURLConfiguration.kt`に移動しました。
- `PayjpThreeDSecureResult`クラスの`SuccessTokenId`を`SuccessResourceId`へ変更しました。
- `PayjpThreeDSecureStepActivity`の内部処理を修正し、tokenIDの処理とResourceIdの処理を統合しました。
## サンプルアプリの更新
- `ThreeDSecureExampleActivity` を追加しました。

| 1 | 2 |
|--------|--------|
| ![Screenshot 2025-03-08 at 20 00 32](https://github.com/user-attachments/assets/cee026bc-87a0-49a3-bf33-9e9ed83310c2) | ![Screenshot 2025-03-08 at 20 00 23](https://github.com/user-attachments/assets/b19cdb45-0c3f-4134-9795-c83cc2688556) |

## レビューのポイント
- TokeinID→ResourceIDの変更が既存の設定に従っているか
- 既存のSDK利用アプリからの移行に問題がないか

iOS SDKの変更： https://github.com/payjp/payjp-ios/pull/95