### PR TITLE
Edge-to-Edge サポート

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,7 +60,7 @@ tasks.named("dokkaHtmlCollector") {
 
 ext {
     minSdkVersion = 16
-    sdkVersion = 34
+    sdkVersion = 35
     numberOfCommits = numberOfCommits()
 }
 

--- a/payjp-android-cardform/src/main/kotlin/jp/pay/android/ui/PayjpCardFormActivity.kt
+++ b/payjp-android-cardform/src/main/kotlin/jp/pay/android/ui/PayjpCardFormActivity.kt
@@ -35,9 +35,6 @@ import androidx.annotation.StringRes
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.IntentCompat
-import androidx.core.view.ViewCompat
-import androidx.core.view.WindowInsetsCompat
-import androidx.core.view.updatePadding
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
 import com.google.android.material.snackbar.Snackbar

--- a/payjp-android-cardform/src/main/kotlin/jp/pay/android/ui/PayjpCardFormActivity.kt
+++ b/payjp-android-cardform/src/main/kotlin/jp/pay/android/ui/PayjpCardFormActivity.kt
@@ -37,6 +37,7 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.IntentCompat
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.updatePadding
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
 import com.google.android.material.snackbar.Snackbar
@@ -48,6 +49,7 @@ import jp.pay.android.model.ExtraAttribute
 import jp.pay.android.model.TenantId
 import jp.pay.android.model.Token
 import jp.pay.android.model.TokenId
+import jp.pay.android.ui.extension.applyWindowInsets
 import jp.pay.android.ui.extension.showWith
 import jp.pay.android.ui.widget.PayjpCardFormAbstractFragment
 import jp.pay.android.ui.widget.PayjpCardFormView
@@ -170,20 +172,7 @@ internal class PayjpCardFormActivity :
         PayjpCardForm.clientInfoInterceptorProvider()?.getClientInfoInterceptor()?.applyClientInfoExtra {
             setCardFormType(PayjpCardForm.getCardFormFaceString(face))
         }
-        ViewCompat.setOnApplyWindowInsetsListener(binding.root) { v, windowInsets ->
-            val insets = arrayOf(
-                windowInsets.getInsets(WindowInsetsCompat.Type.statusBars()),
-                windowInsets.getInsets(WindowInsetsCompat.Type.displayCutout()),
-                windowInsets.getInsets(WindowInsetsCompat.Type.navigationBars())
-            )
-            v.setPadding(
-                insets.maxOf { it.left },
-                insets.maxOf { it.top },
-                insets.maxOf { it.right },
-                insets.maxOf { it.bottom }
-            )
-            WindowInsetsCompat.CONSUMED
-        }
+        binding.root.applyWindowInsets()
     }
 
     override fun onDestroy() {

--- a/payjp-android-cardform/src/main/kotlin/jp/pay/android/ui/PayjpCardFormActivity.kt
+++ b/payjp-android-cardform/src/main/kotlin/jp/pay/android/ui/PayjpCardFormActivity.kt
@@ -35,6 +35,8 @@ import androidx.annotation.StringRes
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.IntentCompat
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
 import com.google.android.material.snackbar.Snackbar
@@ -159,6 +161,7 @@ internal class PayjpCardFormActivity :
         super.onCreate(savedInstanceState)
         binding = PayjpCardFormActivityBinding.inflate(layoutInflater)
         setContentView(binding.root)
+        setSupportActionBar(binding.payjpCardFormToolbar)
         setTitle(R.string.payjp_card_form_screen_title)
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
         setUpUI()
@@ -166,6 +169,20 @@ internal class PayjpCardFormActivity :
 
         PayjpCardForm.clientInfoInterceptorProvider()?.getClientInfoInterceptor()?.applyClientInfoExtra {
             setCardFormType(PayjpCardForm.getCardFormFaceString(face))
+        }
+        ViewCompat.setOnApplyWindowInsetsListener(binding.root) { v, windowInsets ->
+            val insets = arrayOf(
+                windowInsets.getInsets(WindowInsetsCompat.Type.statusBars()),
+                windowInsets.getInsets(WindowInsetsCompat.Type.displayCutout()),
+                windowInsets.getInsets(WindowInsetsCompat.Type.navigationBars())
+            )
+            v.setPadding(
+                insets.maxOf { it.left },
+                insets.maxOf { it.top },
+                insets.maxOf { it.right },
+                insets.maxOf { it.bottom }
+            )
+            WindowInsetsCompat.CONSUMED
         }
     }
 

--- a/payjp-android-cardform/src/main/kotlin/jp/pay/android/ui/PayjpSearchCountryCodeActivity.kt
+++ b/payjp-android-cardform/src/main/kotlin/jp/pay/android/ui/PayjpSearchCountryCodeActivity.kt
@@ -32,6 +32,8 @@ import android.view.ViewGroup
 import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.SearchView
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import jp.pay.android.PayjpCardForm
@@ -66,6 +68,21 @@ internal class PayjpSearchCountryCodeActivity : AppCompatActivity() {
         binding.payjpCountryCodeRecyclerView.layoutManager = LinearLayoutManager(this)
         binding.payjpCountryCodeRecyclerView.adapter = adapter
         adapter.setCountryCodes(PayjpCardForm.phoneNumberService().getAllCountryCodes(this))
+
+        ViewCompat.setOnApplyWindowInsetsListener(binding.root) { v, windowInsets ->
+            val insets = arrayOf(
+                windowInsets.getInsets(WindowInsetsCompat.Type.statusBars()),
+                windowInsets.getInsets(WindowInsetsCompat.Type.displayCutout()),
+                windowInsets.getInsets(WindowInsetsCompat.Type.navigationBars())
+            )
+            v.setPadding(
+                insets.maxOf { it.left },
+                insets.maxOf { it.top },
+                insets.maxOf { it.right },
+                insets.maxOf { it.bottom }
+            )
+            WindowInsetsCompat.CONSUMED
+        }
     }
 
     override fun onSupportNavigateUp(): Boolean {

--- a/payjp-android-cardform/src/main/kotlin/jp/pay/android/ui/PayjpSearchCountryCodeActivity.kt
+++ b/payjp-android-cardform/src/main/kotlin/jp/pay/android/ui/PayjpSearchCountryCodeActivity.kt
@@ -40,6 +40,7 @@ import jp.pay.android.PayjpCardForm
 import jp.pay.android.R
 import jp.pay.android.databinding.PayjpSearchCountryCodeActivityBinding
 import jp.pay.android.model.CountryCode
+import jp.pay.android.ui.extension.applyWindowInsets
 
 internal class PayjpSearchCountryCodeActivity : AppCompatActivity() {
     internal companion object {
@@ -69,20 +70,7 @@ internal class PayjpSearchCountryCodeActivity : AppCompatActivity() {
         binding.payjpCountryCodeRecyclerView.adapter = adapter
         adapter.setCountryCodes(PayjpCardForm.phoneNumberService().getAllCountryCodes(this))
 
-        ViewCompat.setOnApplyWindowInsetsListener(binding.root) { v, windowInsets ->
-            val insets = arrayOf(
-                windowInsets.getInsets(WindowInsetsCompat.Type.statusBars()),
-                windowInsets.getInsets(WindowInsetsCompat.Type.displayCutout()),
-                windowInsets.getInsets(WindowInsetsCompat.Type.navigationBars())
-            )
-            v.setPadding(
-                insets.maxOf { it.left },
-                insets.maxOf { it.top },
-                insets.maxOf { it.right },
-                insets.maxOf { it.bottom }
-            )
-            WindowInsetsCompat.CONSUMED
-        }
+        binding.root.applyWindowInsets()
     }
 
     override fun onSupportNavigateUp(): Boolean {

--- a/payjp-android-cardform/src/main/kotlin/jp/pay/android/ui/PayjpSearchCountryCodeActivity.kt
+++ b/payjp-android-cardform/src/main/kotlin/jp/pay/android/ui/PayjpSearchCountryCodeActivity.kt
@@ -32,8 +32,6 @@ import android.view.ViewGroup
 import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.SearchView
-import androidx.core.view.ViewCompat
-import androidx.core.view.WindowInsetsCompat
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import jp.pay.android.PayjpCardForm

--- a/payjp-android-cardform/src/main/kotlin/jp/pay/android/ui/extension/ViewExtension.kt
+++ b/payjp-android-cardform/src/main/kotlin/jp/pay/android/ui/extension/ViewExtension.kt
@@ -76,6 +76,7 @@ internal fun View.applyWindowInsets() {
             androidx.core.view.WindowInsetsCompat.Type.systemBars()
                     or androidx.core.view.WindowInsetsCompat.Type.displayCutout()
                     or androidx.core.view.WindowInsetsCompat.Type.navigationBars()
+                    or WindowInsetsCompat.Type.ime()
         )
         v.updatePadding(
             left = insets.left,

--- a/payjp-android-cardform/src/main/kotlin/jp/pay/android/ui/extension/ViewExtension.kt
+++ b/payjp-android-cardform/src/main/kotlin/jp/pay/android/ui/extension/ViewExtension.kt
@@ -74,9 +74,9 @@ internal fun View.applyWindowInsets() {
     ViewCompat.setOnApplyWindowInsetsListener(this) { v, windowInsets ->
         val insets = windowInsets.getInsets(
             androidx.core.view.WindowInsetsCompat.Type.systemBars()
-                    or androidx.core.view.WindowInsetsCompat.Type.displayCutout()
-                    or androidx.core.view.WindowInsetsCompat.Type.navigationBars()
-                    or WindowInsetsCompat.Type.ime()
+                or androidx.core.view.WindowInsetsCompat.Type.displayCutout()
+                or androidx.core.view.WindowInsetsCompat.Type.navigationBars()
+                or WindowInsetsCompat.Type.ime()
         )
         v.updatePadding(
             left = insets.left,

--- a/payjp-android-cardform/src/main/res/layout/payjp_card_form_activity.xml
+++ b/payjp-android-cardform/src/main/res/layout/payjp_card_form_activity.xml
@@ -30,104 +30,134 @@
         tools:theme="@style/Payjp.Theme.CardForm">
 
     <androidx.constraintlayout.widget.ConstraintLayout
-            android:id="@+id/content_view"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" >
+
+        <com.google.android.material.appbar.AppBarLayout
+            android:id="@+id/payjp_card_form_toolbar_app_bar"
             android:layout_width="match_parent"
-            android:layout_height="match_parent">
+            android:layout_height="wrap_content"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            android:theme="@style/PayjpToolbar">
+
+            <androidx.appcompat.widget.Toolbar
+                android:id="@+id/payjp_card_form_toolbar"
+                android:layout_width="match_parent"
+                android:layout_height="?attr/actionBarSize"
+                android:background="?attr/colorPrimary"/>
+
+        </com.google.android.material.appbar.AppBarLayout>
 
         <FrameLayout
-                android:id="@+id/button_layout"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="40dp"
-                android:padding="16dp"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent">
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            app:layout_constraintTop_toBottomOf="@id/payjp_card_form_toolbar_app_bar"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent">
 
-            <Button
-                    android:id="@+id/card_form_button"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_gravity="center"
-                    android:minHeight="@dimen/payjp_card_form_submit_button_minheight"
-                    android:text="@string/payjp_card_form_submit" />
-
-            <ProgressBar
-                    android:id="@+id/card_form_button_progress"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_gravity="center" />
-
-        </FrameLayout>
-
-        <ScrollView
-                android:layout_width="0dp"
-                android:layout_height="0dp"
-                app:layout_constraintBottom_toTopOf="@id/button_layout"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent">
-
-            <LinearLayout
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:orientation="vertical">
-
-                <jp.pay.android.ui.widget.PayjpAcceptedBrandsView
-                        android:id="@+id/accepted_brands"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_gravity="center_horizontal"
-                        android:layout_marginTop="16dp"
-                        android:padding="16dp"/>
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:id="@+id/content_view"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent">
 
                 <FrameLayout
-                        android:id="@+id/card_form_view"
+                    android:id="@+id/button_layout"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="40dp"
+                    android:padding="16dp"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent">
+
+                    <Button
+                        android:id="@+id/card_form_button"
                         android:layout_width="match_parent"
-                        android:layout_height="wrap_content" />
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="center"
+                        android:minHeight="@dimen/payjp_card_form_submit_button_minheight"
+                        android:text="@string/payjp_card_form_submit" />
 
-            </LinearLayout>
+                    <ProgressBar
+                        android:id="@+id/card_form_button_progress"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="center" />
 
-        </ScrollView>
+                </FrameLayout>
 
-    </androidx.constraintlayout.widget.ConstraintLayout>
+                <ScrollView
+                    android:layout_width="0dp"
+                    android:layout_height="0dp"
+                    app:layout_constraintBottom_toTopOf="@id/button_layout"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent">
 
-    <ProgressBar
-            android:id="@+id/content_loading_progress"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center" />
+                    <LinearLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:orientation="vertical">
 
-    <androidx.constraintlayout.widget.ConstraintLayout
-            android:id="@+id/error_view"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:padding="16dp">
+                        <jp.pay.android.ui.widget.PayjpAcceptedBrandsView
+                            android:id="@+id/accepted_brands"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_gravity="center_horizontal"
+                            android:layout_marginTop="16dp"
+                            android:padding="16dp"/>
 
-        <TextView
-                android:id="@+id/error_message"
+                        <FrameLayout
+                            android:id="@+id/card_form_view"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content" />
+
+                    </LinearLayout>
+
+                </ScrollView>
+
+            </androidx.constraintlayout.widget.ConstraintLayout>
+
+            <ProgressBar
+                android:id="@+id/content_loading_progress"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:gravity="center_horizontal"
-                style="@style/TextAppearance.MaterialComponents.Body1"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent"
-                tools:text="@string/payjp_card_form_screen_error_network" />
+                android:layout_gravity="center" />
 
-        <Button
-                android:id="@+id/reload_content_button"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="20dp"
-                android:text="@string/payjp_card_form_reload"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/error_message"
-                app:layout_constraintVertical_bias="0" />
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:id="@+id/error_view"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:padding="16dp">
 
+                <TextView
+                    android:id="@+id/error_message"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:gravity="center_horizontal"
+                    style="@style/TextAppearance.MaterialComponents.Body1"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent"
+                    tools:text="@string/payjp_card_form_screen_error_network" />
+
+                <Button
+                    android:id="@+id/reload_content_button"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="20dp"
+                    android:text="@string/payjp_card_form_reload"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/error_message"
+                    app:layout_constraintVertical_bias="0" />
+
+            </androidx.constraintlayout.widget.ConstraintLayout>
+        </FrameLayout>
     </androidx.constraintlayout.widget.ConstraintLayout>
-
 </FrameLayout>

--- a/payjp-android-cardform/src/main/res/values/styles.xml
+++ b/payjp-android-cardform/src/main/res/values/styles.xml
@@ -24,7 +24,7 @@
 
 <resources>
 
-    <style name="Payjp.Theme.BaseCardForm" parent="@style/Theme.MaterialComponents.DayNight.DarkActionBar">
+    <style name="Payjp.Theme.BaseCardForm" parent="@style/Theme.MaterialComponents.DayNight.NoActionBar">
         <item name="buttonStyle">@style/Widget.MaterialComponents.Button</item>
         <item name="textInputStyle">@style/Widget.MaterialComponents.TextInputLayout.FilledBox.Dense</item>
         <item name="colorPrimary">@color/payjp_primaryColor</item>

--- a/sample/src/main/kotlin/com/example/payjp/sample/CardFormViewSampleActivity.kt
+++ b/sample/src/main/kotlin/com/example/payjp/sample/CardFormViewSampleActivity.kt
@@ -34,6 +34,7 @@ import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.app.AppCompatDelegate
 import com.example.payjp.sample.databinding.ActivityCardFormViewSampleBinding
+import com.example.payjp.sample.extension.applyWindowInsets
 import jp.pay.android.Payjp
 import jp.pay.android.PayjpTokenOperationStatus
 import jp.pay.android.Task
@@ -76,6 +77,7 @@ class CardFormViewSampleActivity :
         setTheme(restoreTheme().id)
         binding = ActivityCardFormViewSampleBinding.inflate(layoutInflater)
         setContentView(binding.root)
+        setSupportActionBar(binding.cardFormSampleToolbar)
         findCardFormFragment()
         binding.buttonCreateToken.setOnClickListener {
             if (!cardFormFragment.isValid) {
@@ -92,6 +94,8 @@ class CardFormViewSampleActivity :
         binding.buttonGetToken.setOnClickListener {
             getToken(binding.textTokenId.text.toString())
         }
+
+        binding.root.applyWindowInsets()
 
         Payjp.token().getTokenOperationObserver().addListener { updateButtonVisibility() }
     }

--- a/sample/src/main/kotlin/com/example/payjp/sample/CoroutineSampleActivity.kt
+++ b/sample/src/main/kotlin/com/example/payjp/sample/CoroutineSampleActivity.kt
@@ -29,6 +29,7 @@ import android.view.View
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import com.example.payjp.sample.databinding.ActivityCardFormViewSampleBinding
+import com.example.payjp.sample.extension.applyWindowInsets
 import jp.pay.android.Payjp
 import jp.pay.android.coroutine.createTokenSuspend
 import jp.pay.android.coroutine.finishTokenTdsSuspend
@@ -56,6 +57,7 @@ class CoroutineSampleActivity : AppCompatActivity(), CoroutineScope by MainScope
         super.onCreate(savedInstanceState)
         binding = ActivityCardFormViewSampleBinding.inflate(layoutInflater)
         setContentView(binding.root)
+        setSupportActionBar(binding.cardFormSampleToolbar)
         findCardFormFragment()
         binding.buttonCreateToken.setOnClickListener {
             createToken()
@@ -69,6 +71,8 @@ class CoroutineSampleActivity : AppCompatActivity(), CoroutineScope by MainScope
         binding.buttonGetToken.setOnClickListener {
             getToken(binding.textTokenId.text.toString())
         }
+
+        binding.root.applyWindowInsets()
     }
 
     override fun onDestroy() {

--- a/sample/src/main/kotlin/com/example/payjp/sample/ThreeDSecureExampleActivity.kt
+++ b/sample/src/main/kotlin/com/example/payjp/sample/ThreeDSecureExampleActivity.kt
@@ -32,6 +32,7 @@ import android.widget.TextView
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.graphics.toColorInt
+import com.example.payjp.sample.extension.applyWindowInsets
 import jp.pay.android.verifier.PayjpVerifier
 
 class ThreeDSecureExampleActivity : AppCompatActivity() {
@@ -41,6 +42,7 @@ class ThreeDSecureExampleActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_three_d_secure_example)
+        setSupportActionBar(findViewById(R.id.three_d_secure_sample_toolbar))
 
         val resourceIdInput = findViewById<EditText>(R.id.resource_id_input)
         val start3DSecureButton = findViewById<Button>(R.id.start_3d_secure_button)
@@ -61,6 +63,8 @@ class ThreeDSecureExampleActivity : AppCompatActivity() {
                 Toast.makeText(this, "Please enter a resource ID", Toast.LENGTH_SHORT).show()
             }
         }
+
+        window.decorView.rootView.applyWindowInsets()
     }
 
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {

--- a/sample/src/main/kotlin/com/example/payjp/sample/TopActivity.kt
+++ b/sample/src/main/kotlin/com/example/payjp/sample/TopActivity.kt
@@ -35,6 +35,7 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.example.payjp.sample.databinding.ActivityTopBinding
 import com.example.payjp.sample.databinding.CardSampleBinding
+import com.example.payjp.sample.extension.applyWindowInsets
 import jp.pay.android.Payjp
 import jp.pay.android.PayjpCardForm
 import jp.pay.android.model.ExtraAttribute
@@ -96,12 +97,14 @@ class TopActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         binding = ActivityTopBinding.inflate(layoutInflater)
         setContentView(binding.root)
+        setSupportActionBar(binding.topToolbar)
         binding.recyclerView.let {
             it.layoutManager = LinearLayoutManager(this)
             it.adapter = TopAdapter(this, samples) { sample ->
                 sample.start(this)
             }
         }
+        binding.root.applyWindowInsets()
     }
 
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {

--- a/sample/src/main/kotlin/com/example/payjp/sample/extension/ViewExtension.kt
+++ b/sample/src/main/kotlin/com/example/payjp/sample/extension/ViewExtension.kt
@@ -35,9 +35,9 @@ internal fun View.applyWindowInsets() {
     ViewCompat.setOnApplyWindowInsetsListener(this) { v, windowInsets ->
         val insets = windowInsets.getInsets(
             androidx.core.view.WindowInsetsCompat.Type.systemBars()
-                    or androidx.core.view.WindowInsetsCompat.Type.displayCutout()
-                    or androidx.core.view.WindowInsetsCompat.Type.navigationBars()
-                    or WindowInsetsCompat.Type.ime()
+                or androidx.core.view.WindowInsetsCompat.Type.displayCutout()
+                or androidx.core.view.WindowInsetsCompat.Type.navigationBars()
+                or WindowInsetsCompat.Type.ime()
         )
         v.updatePadding(
             left = insets.left,

--- a/sample/src/main/kotlin/com/example/payjp/sample/extension/ViewExtension.kt
+++ b/sample/src/main/kotlin/com/example/payjp/sample/extension/ViewExtension.kt
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright (c) 2021 PAY, Inc.
+ * Copyright (c) 2025 PAY, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -20,52 +20,13 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-@file:JvmName("ViewExtension")
 
-package jp.pay.android.ui.extension
+package com.example.payjp.sample.extension
 
-import android.app.Dialog
-import android.text.Editable
-import android.text.TextWatcher
 import android.view.View
-import android.widget.TextView
-import androidx.activity.ComponentActivity
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.updatePadding
-import com.google.android.material.textfield.TextInputLayout
-import jp.pay.android.ui.widget.DialogHolder
-
-internal typealias TextViewOnTextChanged = ((s: CharSequence, start: Int, before: Int, count: Int) -> Unit)
-
-internal fun TextInputLayout.setErrorOrNull(error: CharSequence?) {
-    this.isErrorEnabled = error.isNullOrEmpty().not()
-    this.error = error
-}
-
-internal fun TextView.addOnTextChanged(
-    onTextChanged: TextViewOnTextChanged?
-) {
-    addTextChangedListener(
-        object : TextWatcher {
-            override fun afterTextChanged(s: Editable) = Unit
-
-            override fun beforeTextChanged(s: CharSequence, start: Int, count: Int, after: Int) = Unit
-
-            override fun onTextChanged(s: CharSequence, start: Int, before: Int, count: Int) =
-                onTextChanged?.invoke(s, start, before, count) ?: Unit
-        }
-    )
-}
-
-/**
- * Show with lifecycle awareness of activity using [jp.pay.android.ui.widget.DialogHolder].
- *
- * @param activity host activity
- */
-internal fun Dialog.showWith(activity: ComponentActivity) {
-    DialogHolder(this).show(activity)
-}
 
 /**
  * Apply insets padding to activity root view for Edge to Edge

--- a/sample/src/main/kotlin/com/example/payjp/sample/extension/ViewExtension.kt
+++ b/sample/src/main/kotlin/com/example/payjp/sample/extension/ViewExtension.kt
@@ -37,6 +37,7 @@ internal fun View.applyWindowInsets() {
             androidx.core.view.WindowInsetsCompat.Type.systemBars()
                     or androidx.core.view.WindowInsetsCompat.Type.displayCutout()
                     or androidx.core.view.WindowInsetsCompat.Type.navigationBars()
+                    or WindowInsetsCompat.Type.ime()
         )
         v.updatePadding(
             left = insets.left,

--- a/sample/src/main/kotlin/com/example/payjp/sample/extension/ViewExtension.kt
+++ b/sample/src/main/kotlin/com/example/payjp/sample/extension/ViewExtension.kt
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright (c) 2025 PAY, Inc.
+ * Copyright (c) 2021 PAY, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -20,7 +20,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package com.example.payjp.sample.extension
 
 import android.view.View

--- a/sample/src/main/res/layout/activity_card_form_view_sample.xml
+++ b/sample/src/main/res/layout/activity_card_form_view_sample.xml
@@ -21,41 +21,62 @@
   ~ SOFTWARE.
   -->
 
-<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
-        xmlns:tools="http://schemas.android.com/tools"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent">
+<androidx.coordinatorlayout.widget.CoordinatorLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
 
-    <LinearLayout
+    <com.google.android.material.appbar.AppBarLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:theme="@style/PayjpToolbar">
+
+        <androidx.appcompat.widget.Toolbar
+            android:id="@+id/card_form_sample_toolbar"
+            android:layout_width="match_parent"
+            android:layout_height="?attr/actionBarSize"
+            android:background="?attr/colorPrimary"
+            app:popupTheme="@style/MenuItemStyle" />
+
+    </com.google.android.material.appbar.AppBarLayout>
+
+    <ScrollView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior">
+
+        <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:orientation="vertical"
             android:padding="16dp"
             tools:ignore="HardcodedText">
 
-        <FrameLayout
+            <FrameLayout
                 android:id="@+id/card_form_view"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent" />
 
-        <FrameLayout
+            <FrameLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content">
 
-            <LinearLayout
+                <LinearLayout
                     android:id="@+id/layout_buttons"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:orientation="vertical">
 
-                <LinearLayout
+                    <LinearLayout
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:layout_marginTop="16dp"
                         android:baselineAligned="false"
                         android:orientation="horizontal">
 
-                    <Button
+                        <Button
                             android:id="@+id/button_create_token"
                             style="?android:buttonStyle"
                             android:layout_width="0dp"
@@ -65,7 +86,7 @@
                             android:text="create token"
                             tools:ignore="RtlCompat" />
 
-                    <Button
+                        <Button
                             android:id="@+id/button_create_token_with_validate"
                             style="?android:buttonStyle"
                             android:layout_width="0dp"
@@ -75,9 +96,9 @@
                             android:text="validate form and create token"
                             tools:ignore="RtlCompat" />
 
-                </LinearLayout>
+                    </LinearLayout>
 
-                <Button
+                    <Button
                         android:id="@+id/button_get_token"
                         style="?android:buttonStyle"
                         android:layout_width="match_parent"
@@ -85,9 +106,9 @@
                         android:layout_marginTop="8dp"
                         android:text="get token by id" />
 
-            </LinearLayout>
+                </LinearLayout>
 
-            <ProgressBar
+                <ProgressBar
                     android:id="@+id/progress_bar"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
@@ -95,9 +116,9 @@
                     android:layout_margin="16dp"
                     android:visibility="gone" />
 
-        </FrameLayout>
+            </FrameLayout>
 
-        <EditText
+            <EditText
                 android:id="@+id/text_token_id"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
@@ -110,7 +131,7 @@
                 android:longClickable="false"
                 android:textSize="14sp" />
 
-        <TextView
+            <TextView
                 android:id="@+id/text_token_content"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
@@ -120,7 +141,7 @@
                 android:layout_marginBottom="8dp"
                 android:text="The token will be shown here." />
 
-    </LinearLayout>
+        </LinearLayout>
+    </ScrollView>
 
-
-</ScrollView>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/sample/src/main/res/layout/activity_three_d_secure_example.xml
+++ b/sample/src/main/res/layout/activity_three_d_secure_example.xml
@@ -1,174 +1,195 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.coordinatorlayout.widget.CoordinatorLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <LinearLayout
+    <com.google.android.material.appbar.AppBarLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="vertical"
-        android:padding="16dp">
+        android:theme="@style/PayjpToolbar">
 
-        <TextView
+        <androidx.appcompat.widget.Toolbar
+            android:id="@+id/three_d_secure_sample_toolbar"
+            android:layout_width="match_parent"
+            android:layout_height="?attr/actionBarSize"
+            android:background="?attr/colorPrimary" />
+
+    </com.google.android.material.appbar.AppBarLayout>
+
+    <ScrollView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior" >
+
+        <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="3Dセキュア"
-            android:textSize="24sp"
-            android:textStyle="bold"
-            android:layout_marginBottom="16dp" />
+            android:orientation="vertical"
+            android:padding="16dp">
 
-        <androidx.cardview.widget.CardView
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginBottom="16dp"
-            app:cardCornerRadius="8dp"
-            app:cardElevation="4dp">
-
-            <LinearLayout
+            <TextView
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:orientation="vertical"
-                android:padding="16dp">
+                android:layout_marginBottom="16dp"
+                android:text="3Dセキュア"
+                android:textSize="24sp"
+                android:textStyle="bold" />
 
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="リソースID"
-                    android:textStyle="bold"
-                    android:layout_marginBottom="8dp" />
-
-                <com.google.android.material.textfield.TextInputLayout
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:hint="リソースIDを入力">
-
-                    <com.google.android.material.textfield.TextInputEditText
-                        android:id="@+id/resource_id_input"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:inputType="text"
-                        android:text="tdsr_ce3c1d805452c981775e321288a" />
-                </com.google.android.material.textfield.TextInputLayout>
-
-                <com.google.android.material.button.MaterialButton
-                    android:id="@+id/start_3d_secure_button"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="16dp"
-                    android:text="3Dセキュア認証を開始"
-                    app:icon="@android:drawable/ic_lock_lock" />
-            </LinearLayout>
-        </androidx.cardview.widget.CardView>
-
-        <TextView
-                    android:id="@+id/complete_message"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:text=""
-                    android:textSize="14sp"
-                    android:background="#E8F5E9"
-                    android:visibility="gone"
-                    android:padding="8dp" />
-
-        <androidx.cardview.widget.CardView
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            app:cardCornerRadius="8dp"
-            app:cardElevation="2dp">
-
-            <LinearLayout
+            <androidx.cardview.widget.CardView
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:orientation="vertical"
-                android:padding="16dp">
-
-                <TextView
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:text="手順"
-                    android:textStyle="bold"
-                    android:textSize="18sp"
-                    android:layout_marginBottom="16dp" />
+                android:layout_marginBottom="16dp"
+                app:cardCornerRadius="8dp"
+                app:cardElevation="4dp">
 
                 <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:orientation="horizontal"
-                    android:layout_marginBottom="12dp">
+                    android:orientation="vertical"
+                    android:padding="16dp">
 
                     <TextView
-                        android:layout_width="36dp"
-                        android:layout_height="36dp"
-                        android:text="1"
-                        android:textSize="18sp"
-                        android:textStyle="bold"
-                        android:gravity="center"
-                        android:textColor="#FFFFFF"
-                        android:background="@android:color/holo_blue_dark"
-                        android:layout_marginEnd="12dp"
-                        android:layout_marginRight="12dp" />
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginBottom="8dp"
+                        android:text="リソースID"
+                        android:textStyle="bold" />
 
-                    <TextView
+                    <com.google.android.material.textfield.TextInputLayout
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:minHeight="200dp"
-                        android:autoLink="web"
-                        android:text="下記を参考に、先にサーバーサイドで支払い、または3Dセキュアリクエストを作成してください。\n\n支払い作成時の3Dセキュア：\nhttps://pay.jp/docs/charge-tds\n顧客カードに対する3Dセキュア：\nhttps://pay.jp/docs/customer-card-tds"
-                        android:textSize="14sp" />
+                        android:hint="リソースIDを入力">
+
+                        <com.google.android.material.textfield.TextInputEditText
+                            android:id="@+id/resource_id_input"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:inputType="text"
+                            android:text="tdsr_ce3c1d805452c981775e321288a" />
+                    </com.google.android.material.textfield.TextInputLayout>
+
+                    <com.google.android.material.button.MaterialButton
+                        android:id="@+id/start_3d_secure_button"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="16dp"
+                        android:text="3Dセキュア認証を開始"
+                        app:icon="@android:drawable/ic_lock_lock" />
                 </LinearLayout>
+            </androidx.cardview.widget.CardView>
+
+            <TextView
+                android:id="@+id/complete_message"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:background="#E8F5E9"
+                android:padding="8dp"
+                android:text=""
+                android:textSize="14sp"
+                android:visibility="gone" />
+
+            <androidx.cardview.widget.CardView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:cardCornerRadius="8dp"
+                app:cardElevation="2dp">
 
                 <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:orientation="horizontal"
-                    android:layout_marginBottom="12dp">
-
-                    <TextView
-                        android:layout_width="36dp"
-                        android:layout_height="36dp"
-                        android:text="2"
-                        android:textSize="18sp"
-                        android:textStyle="bold"
-                        android:gravity="center"
-                        android:textColor="#FFFFFF"
-                        android:background="@android:color/holo_blue_dark"
-                        android:layout_marginEnd="12dp"
-                        android:layout_marginRight="12dp" />
+                    android:orientation="vertical"
+                    android:padding="16dp">
 
                     <TextView
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:minHeight="100dp"
-                        android:text="作成したリソースのIDを上記に入力して3Dセキュアを開始してください。"
-                        android:textSize="14sp" />
-                </LinearLayout>
-
-                <LinearLayout
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:orientation="horizontal">
-
-                    <TextView
-                        android:layout_width="36dp"
-                        android:layout_height="36dp"
-                        android:text="3"
+                        android:layout_marginBottom="16dp"
+                        android:text="手順"
                         android:textSize="18sp"
-                        android:textStyle="bold"
-                        android:gravity="center"
-                        android:textColor="#FFFFFF"
-                        android:background="@android:color/holo_blue_dark"
-                        android:layout_marginEnd="12dp"
-                        android:layout_marginRight="12dp" />
+                        android:textStyle="bold" />
 
-                    <TextView
+                    <LinearLayout
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:minHeight="100dp"
-                        android:text="立ち上がった画面が閉じ、認証が終了したら、ドキュメントを参考にサーバーサイドにて結果を確認してください。"
-                        android:textSize="14sp" />
+                        android:layout_marginBottom="12dp"
+                        android:orientation="horizontal">
+
+                        <TextView
+                            android:layout_width="36dp"
+                            android:layout_height="36dp"
+                            android:layout_marginEnd="12dp"
+                            android:layout_marginRight="12dp"
+                            android:background="@android:color/holo_blue_dark"
+                            android:gravity="center"
+                            android:text="1"
+                            android:textColor="#FFFFFF"
+                            android:textSize="18sp"
+                            android:textStyle="bold" />
+
+                        <TextView
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:autoLink="web"
+                            android:minHeight="200dp"
+                            android:text="下記を参考に、先にサーバーサイドで支払い、または3Dセキュアリクエストを作成してください。\n\n支払い作成時の3Dセキュア：\nhttps://pay.jp/docs/charge-tds\n顧客カードに対する3Dセキュア：\nhttps://pay.jp/docs/customer-card-tds"
+                            android:textSize="14sp" />
+                    </LinearLayout>
+
+                    <LinearLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginBottom="12dp"
+                        android:orientation="horizontal">
+
+                        <TextView
+                            android:layout_width="36dp"
+                            android:layout_height="36dp"
+                            android:layout_marginEnd="12dp"
+                            android:layout_marginRight="12dp"
+                            android:background="@android:color/holo_blue_dark"
+                            android:gravity="center"
+                            android:text="2"
+                            android:textColor="#FFFFFF"
+                            android:textSize="18sp"
+                            android:textStyle="bold" />
+
+                        <TextView
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:minHeight="100dp"
+                            android:text="作成したリソースのIDを上記に入力して3Dセキュアを開始してください。"
+                            android:textSize="14sp" />
+                    </LinearLayout>
+
+                    <LinearLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:orientation="horizontal">
+
+                        <TextView
+                            android:layout_width="36dp"
+                            android:layout_height="36dp"
+                            android:layout_marginEnd="12dp"
+                            android:layout_marginRight="12dp"
+                            android:background="@android:color/holo_blue_dark"
+                            android:gravity="center"
+                            android:text="3"
+                            android:textColor="#FFFFFF"
+                            android:textSize="18sp"
+                            android:textStyle="bold" />
+
+                        <TextView
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:minHeight="100dp"
+                            android:text="立ち上がった画面が閉じ、認証が終了したら、ドキュメントを参考にサーバーサイドにて結果を確認してください。"
+                            android:textSize="14sp" />
+                    </LinearLayout>
                 </LinearLayout>
-            </LinearLayout>
-        </androidx.cardview.widget.CardView>
-    </LinearLayout>
-</ScrollView>
+            </androidx.cardview.widget.CardView>
+        </LinearLayout>
+    </ScrollView>
+
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/sample/src/main/res/values-night/colors.xml
+++ b/sample/src/main/res/values-night/colors.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
   ~
-  ~ Copyright (c) 2019 PAY, Inc.
+  ~ Copyright (c) 2018 PAY, Inc.
   ~
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the "Software"), to deal
@@ -21,30 +21,9 @@
   ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
   ~ SOFTWARE.
   -->
-<androidx.coordinatorlayout.widget.CoordinatorLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent" >
 
-    <com.google.android.material.appbar.AppBarLayout
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:theme="@style/PayjpToolbar">
-
-        <androidx.appcompat.widget.Toolbar
-            android:id="@+id/top_toolbar"
-            android:layout_width="match_parent"
-            android:layout_height="?attr/actionBarSize"
-            android:background="?attr/colorPrimary"/>
-
-    </com.google.android.material.appbar.AppBarLayout>
-
-    <androidx.recyclerview.widget.RecyclerView
-        android:id="@+id/recycler_view"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:layout_marginTop="16dp"
-        app:layout_behavior="@string/appbar_scrolling_view_behavior" />
-
-</androidx.coordinatorlayout.widget.CoordinatorLayout>
+<resources>
+    <!-- Night mode colors -->
+    <color name="menu_popup_background_color">#000000</color>
+    <color name="menu_item_text_color">#ffffff</color>
+</resources>

--- a/sample/src/main/res/values/colors.xml
+++ b/sample/src/main/res/values/colors.xml
@@ -36,4 +36,8 @@
     <color name="secondaryDarkColor">#c79400</color>
     <color name="primaryTextColor">#424242</color>
     <color name="secondaryTextColor">#37474f</color>
+    
+    <!-- Menu colors for theme switching -->
+    <color name="menu_popup_background_color">#ffffff</color>
+    <color name="menu_item_text_color">#000000</color>
 </resources>

--- a/sample/src/main/res/values/styles.xml
+++ b/sample/src/main/res/values/styles.xml
@@ -24,14 +24,14 @@
 <resources>
 
     <!-- Base application theme. -->
-    <style name="AppTheme" parent="Theme.AppCompat.DayNight.DarkActionBar">
+    <style name="AppTheme" parent="Theme.AppCompat.DayNight.NoActionBar">
         <!-- Customize your theme here. -->
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
         <item name="colorAccent">@color/colorAccent</item>
     </style>
 
-    <style name="Material" parent="Theme.MaterialComponents.DayNight.DarkActionBar">
+    <style name="Material" parent="Theme.MaterialComponents.DayNight.NoActionBar">
         <item name="colorPrimary">@color/primaryColor</item>
         <item name="colorPrimaryDark">@color/primaryDarkColor</item>
         <item name="colorAccent">@color/secondaryColor</item>
@@ -59,6 +59,12 @@
 
     <style name="MaterialTextFieldFilledDense" parent="Widget.MaterialComponents.TextInputLayout.FilledBox.Dense">
         <!-- customize -->
+    </style>
+
+    <!-- Menu item style for theme switching -->
+    <style name="MenuItemStyle">
+        <item name="android:colorBackground">@color/menu_popup_background_color</item>
+        <item name="android:textColor">@color/menu_item_text_color</item>
     </style>
 
     <!-- Customize CardForm -->


### PR DESCRIPTION
## 概要

Android 15からのEdge-to-Edgeのサポート追加

* 対応内容
    * ViewCompat.setOnApplyWindowInsetsListenerの実装
        * 内部でinsetを取得
        * Edge-to-Edge表示に干渉するviewにinsetを設定する
    * ActionBarを使用している場合、inset情報に含まれない
        * themeをNoActionBarに変更しlayout xmlで別途toolbarを配置

## 関連Issues

* #74 

### 動作検証

* 前提
    * APIレベルを35にしてEdge-to-Edgeを有効にして検証しています
* 検証機種：Pixel 9 Pro - Android OS 15

| 変更前 | 変更後 |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/e19bdffc-86fc-4349-a0e1-fdaba68e03ae" width="240" /> | <img src="https://github.com/user-attachments/assets/7549be5a-3b0d-412f-8f88-4f5dd8d96439" width="240" /> |
| <img src="https://github.com/user-attachments/assets/97e7ae18-4e48-4cfe-b279-d8fb75b639a7" width="240" /> | <img src="https://github.com/user-attachments/assets/be01890b-6b75-4057-98f9-c02b63b3c324" width="240" /> |
| <img src="https://github.com/user-attachments/assets/c6156113-84f7-49ea-914f-c9c47fa329dd" width="240" /> | <img src="https://github.com/user-attachments/assets/588bfce7-b644-4725-92c1-149a42669ea7" width="240" /> |
| <img src="https://github.com/user-attachments/assets/11b32bce-f29d-4fca-aa9f-ddd65ce53dfb" width="240" /> | <img src="https://github.com/user-attachments/assets/2586f14a-b168-4c3a-a91c-084aaee8787d" width="240" /> |
| <img src="https://github.com/user-attachments/assets/11e4001a-63dc-4b1c-9d8f-0b5bf8849948" width="240" /> | <img src="https://github.com/user-attachments/assets/45a2b2bc-edc2-410c-af4a-c6fe0326a6dc" width="240" /> |
| <img src="https://github.com/user-attachments/assets/cc12ebe6-de67-4906-8e14-9d6cd18cdb19" width="240" /> | <img src="https://github.com/user-attachments/assets/80a98a33-529a-40db-8f26-106a4f7cecfa" width="240" /> |




