### PR TITLE
カード名義入力時にフォーカスが外れないように修正

### DIFF
--- a/payjp-android-cardform/src/main/kotlin/jp/pay/android/model/FormInputError.kt
+++ b/payjp-android-cardform/src/main/kotlin/jp/pay/android/model/FormInputError.kt
@@ -30,6 +30,6 @@ import androidx.annotation.StringRes
  * @param messageId res id.
  * @param lazy represent no need to show error immediately (it maybe better to continue input for experience).
  */
-internal data class FormInputError(@StringRes val messageId: Int, val lazy: Boolean) {
+internal data class FormInputError(@StringRes val messageId: Int, val lazy: Boolean, val isMaintainFocus: Boolean = false) {
     fun take(lazy: Boolean): Int? = messageId.takeIf { !lazy || !this.lazy }
 }

--- a/payjp-android-cardform/src/main/kotlin/jp/pay/android/ui/widget/CardFormElementViewHolder.kt
+++ b/payjp-android-cardform/src/main/kotlin/jp/pay/android/ui/widget/CardFormElementViewHolder.kt
@@ -124,6 +124,11 @@ internal sealed class CardFormElementViewHolder<V : ViewBinding>(
                 itemView.resources.getString(it)
             }
         )
+        if (input?.errorMessage?.isMaintainFocus == true) {
+            editText.post {
+                editText.requestFocus()
+            }
+        }
     }
 
     class CardFormNumberElement(

--- a/payjp-android-cardform/src/main/kotlin/jp/pay/android/validator/CardHolderNameInputTransformer.kt
+++ b/payjp-android-cardform/src/main/kotlin/jp/pay/android/validator/CardHolderNameInputTransformer.kt
@@ -35,7 +35,12 @@ internal object CardHolderNameInputTransformer :
                 R.string.payjp_card_form_error_no_holder_name,
                 true
             )
-            (MIN_LENGTH..MAX_LENGTH).contains(trimmed.length).not() -> FormInputError(
+            (trimmed.length >= MIN_LENGTH).not() -> FormInputError(
+                R.string.payjp_card_form_error_invalid_length_holder_name,
+                lazy = false,
+                isMaintainFocus = true
+            )
+            (trimmed.length > MAX_LENGTH) -> FormInputError(
                 R.string.payjp_card_form_error_invalid_length_holder_name,
                 false
             )

--- a/payjp-android-cardform/src/test/kotlin/jp/pay/android/model/CardHolderNameInputTest.kt
+++ b/payjp-android-cardform/src/test/kotlin/jp/pay/android/model/CardHolderNameInputTest.kt
@@ -97,7 +97,7 @@ internal class CardHolderNameInputTest(
                 arrayOf(
                     "1",
                     null,
-                    FormInputError(R.string.payjp_card_form_error_invalid_length_holder_name, false)
+                    FormInputError(R.string.payjp_card_form_error_invalid_length_holder_name, false, true)
                 ),
                 // MIN_LENGTH (2)
                 arrayOf(


### PR DESCRIPTION
## 概要

カード名義入力時にフォーカスが外れないように修正

* 対応内容
    * カード名義のバリデーションが実行された時にフォーカスを付け直す処理を追加

## 関連Issues

* #75  

### 動作検証（エミュレータ）

### Pixel 9 Pro - Android 15

https://github.com/user-attachments/assets/58d08749-3c8c-4cfe-ac72-9c16e3943681


### Pixel 7 Pro - Android 13 

https://github.com/user-attachments/assets/be59155f-2f6e-4b69-a1f4-e2a79708df69

