### PR TITLE
SNAPSHOT配布をbuildワークフローから独立させる

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           java-version: ${{ env.USER_JAVA_VERSION }}
           distribution: "zulu"
-      - uses: gradle/actions/setup-gradle@v3
+      - uses: gradle/actions/setup-gradle@v4
       - name: Cache Gems
         uses: actions/cache@v4
         with:
@@ -50,33 +50,3 @@ jobs:
           bundle install --jobs 4 --retry 3
       - name: Run all checks
         run: bundle exec fastlane android check
-
-  deploy-snapshot:
-    # only run on master branch
-    if: github.ref == 'refs/heads/master'
-    needs: build
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
-        with:
-          java-version: ${{ env.USER_JAVA_VERSION }}
-          distribution: "zulu"
-      - uses: gradle/actions/setup-gradle@v3
-      - name: publish to sonatype
-        # look up version name from gradle.properties, and only snapshot version can be deployed
-        # if non-snapshot version, skip the next steps
-        run: |
-          VERSION_NAME=$(grep "VERSION_NAME" gradle.properties | cut -d'=' -f2)
-          if [[ $VERSION_NAME == *"SNAPSHOT"* ]]; then
-            echo "Deploying snapshot version $VERSION_NAME"
-            ./gradlew publish
-          else
-            echo "Not deploying non-snapshot version $VERSION_NAME"
-          fi
-        env:
-          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
-          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
-          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.GPG_KEY }}
-          ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.GPG_KEY_ID }}
-          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.GPG_KEY_PASSWORD }}

--- a/.github/workflows/deploy-snapshot.yml
+++ b/.github/workflows/deploy-snapshot.yml
@@ -1,0 +1,42 @@
+name: Deploy Snapshot
+
+on:
+  workflow_run:
+    workflows: ["Build and Test"]
+    branches: [master]
+    types:
+      - completed
+
+env:
+  CACHE_NUMBER: 0 # increment to truncate cache
+  USER_JAVA_VERSION: 17
+
+jobs:
+  deploy-snapshot:
+    # only run when the previous workflow succeeded and on master branch
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          java-version: ${{ env.USER_JAVA_VERSION }}
+          distribution: "zulu"
+      - uses: gradle/actions/setup-gradle@v4
+      - name: publish to sonatype
+        # look up version name from gradle.properties, and only snapshot version can be deployed
+        # if non-snapshot version, skip the next steps
+        run: |
+          VERSION_NAME=$(grep "VERSION_NAME" gradle.properties | cut -d'=' -f2)
+          if [[ $VERSION_NAME == *"SNAPSHOT"* ]]; then
+            echo "Deploying snapshot version $VERSION_NAME"
+            ./gradlew publish
+          else
+            echo "Not deploying non-snapshot version $VERSION_NAME"
+          fi
+        env:
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.GPG_KEY }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.GPG_KEY_ID }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.GPG_KEY_PASSWORD }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           java-version: ${{ env.USER_JAVA_VERSION }}
           distribution: "zulu"
-      - uses: gradle/actions/setup-gradle@v3
+      - uses: gradle/actions/setup-gradle@v4
       - name: publish to sonatype
         run: |
           ./gradlew publish


### PR DESCRIPTION
別のワークフローにすることでforkしたブランチからのPRでテストを実行できるようにする