### PR TITLE
CIでのリリースを修正

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -35,7 +35,7 @@ android.useAndroidX=true
 kotlin.parallel.tasks.in.project=true
 
 # Upload config
-SONATYPE_HOST=DEFAULT
+SONATYPE_HOST=CENTRAL_PORTAL
 RELEASE_SIGNING_ENABLED=true
 
 GROUP=jp.pay


### PR DESCRIPTION
- https://github.com/payjp/payjp-android/actions/runs/20499540102

```
FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':payjp-android-cardio:createStagingRepository'.
> A failure occurred while executing com.vanniktech.maven.publish.sonatype.CreateSonatypeRepositoryTask$CreateStagingRepository
   > Cannot get stagingProfiles for account ***: (401) 
```

- アップロード先の古いsonatypeが終わったので、移行先のCentral Portalへのアップロードに対応
- https://central.sonatype.org/news/20250326_ossrh_sunset/