### PR TITLE
upgrade actions node24

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -21,14 +21,14 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-java@v5
         with:
           java-version: ${{ env.USER_JAVA_VERSION }}
           distribution: "zulu"
-      - uses: gradle/actions/setup-gradle@v4
+      - uses: gradle/actions/setup-gradle@v5
       - name: Cache Gems
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: vendor/bundle
           key: ${{ runner.os }}-gems-${{ env.CACHE_NUMBER }}-${{ hashFiles('**/Gemfile.lock') }}

--- a/.github/workflows/deploy-snapshot.yml
+++ b/.github/workflows/deploy-snapshot.yml
@@ -17,12 +17,12 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-java@v5
         with:
           java-version: ${{ env.USER_JAVA_VERSION }}
           distribution: "zulu"
-      - uses: gradle/actions/setup-gradle@v4
+      - uses: gradle/actions/setup-gradle@v5
       - name: publish to sonatype
         # look up version name from gradle.properties, and only snapshot version can be deployed
         # if non-snapshot version, skip the next steps

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,12 +11,12 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-java@v5
         with:
           java-version: ${{ env.USER_JAVA_VERSION }}
           distribution: "zulu"
-      - uses: gradle/actions/setup-gradle@v4
+      - uses: gradle/actions/setup-gradle@v5
       - name: publish to sonatype
         run: |
           ./gradlew publish

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ fastlane/screenshots
 fastlane/test_output
 fastlane/console_output.log
 fastlane/gcloud-client-secret.json
+
+# claude
+.serena


### PR DESCRIPTION
## 概要
GitHub ActionsランナーのNode.js 20が2026年4月にEOLとなり、2026年6月16日からNode 24がデフォルト化されます。
これに伴い、ワークフローで使用しているアクションをNode 24対応バージョンへ更新します。

## 変更点
### ■ 修正内容
GitHubのアクションをNode 24対応バージョンへ更新
### ■ 影響範囲
* リリースフローなどGitHubアクションがNode 24対応バージョンで実行される。
## 確認項目
* [x] ブランチ作成、masterマージ、リリース時にGitHubアクションが正常に終了すること